### PR TITLE
CHI number validation + synthetic generate() default (2.0.0)

### DIFF
--- a/docs/_assets/_snippets/scottish-chi-number.md
+++ b/docs/_assets/_snippets/scottish-chi-number.md
@@ -1,2 +1,0 @@
-!!! note "Scottish CHI Number validation"
-    At present, this library does not reliably validate Scottish CHI Numbers. This is because the first 6 digits of a Scottish CHI Number must be a valid DDMMYY Date of Birth, and this library does not currently check for this. At the moment, only the correct number range is checked for.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,8 @@ title: Changelog
 authors: Dr Marcus Baw
 ---
 
-## 1.3.7
+
+## 1.4.0
 
 - Add a check to ensure CHI numbers start with a date
 - Generated numbers now come from synthetic range

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,14 @@ title: Changelog
 authors: Dr Marcus Baw
 ---
 
+## 1.3.7
+
+- Add a check to ensure CHI numbers start with a date
+- Generated numbers now come from synthetic range
+- Generated numbers from Scottish range will start with a date
+
 ## 1.3.6
+
 - Adds Python 3.13 to the supported versions which are tested in the GitHub Action CI/CD pipeline. No versions have been removed.
 - Adds a Github Action workflow to publish the documentation site to GitHub Pages.
 - Removes the now-defunct `uk-fci.tech` domain in all of this package, replacing with (for now) uk-fci.github.io until we decide what to do with the `uk-fci` GH organisation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,12 +37,6 @@ This package aims to provide a single, well-maintained, well-documented solution
 docs/_assets/_snippets/live-usage-warning.md
 --8<--
 
---8<--
-docs/_assets/_snippets/scottish-chi-number.md
---8<--
-
 ## Roadmap
 
-- Additional validation for Scottish CHI numbers to ensure the first 6 digits are a valid `DDMMYY` Date of Birth.
-- Generation of valid Scottish CHI numbers along the same rules.
 - Validation and generation of [IHI Numbers for the Republic of Ireland](ihi-ireland.md), subject to contributors wanting to collaborate on this, and there being a demand for implementation.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,7 +19,7 @@ Returns `False` if the NHS Number is not valid.
       - `123-456-7890`
       - `1234567890`
 - `for_region` (*optional, default=None, `Region`*): If provided, additionally validates number is included within the given [`Region`](#regions) range.
-- `sex` (*optional, default=None, `str`*): If provided and the number is in the Scottish range will check if the identifying digit matches the supplied label. Excepted options are `male` or `female`.
+- `sex` (*optional, default=None, enum `Sex`*): If provided and the number is in the Scottish range will check if the identifying digit matches the corresponding sex.
 
 ```python
 import nhs_number
@@ -38,21 +38,23 @@ nhs_number.is_valid('7709030025', for_region=nhs_number.REGION_ENGLAND)
 # True
 ```
 
-The `sex` parameter takes either `male` or `female` and can be used to add additional checks for CHI numbers. Supplying a region is optional which is useful if you want to check for the identified sex when dealing with mixed region numbers. For anything other than CHI this is ignored even if supplied.
+The `sex` parameter takes an enum, `Sex`, of with options MALE or FEMALE and can be used to add additional checks for CHI numbers. Supplying a region is optional which is useful if you want to check for the identified sex when dealing with mixed region numbers. For anything other than CHI this is ignored even if supplied.
 
 ```python
 
-nhs_number.is_valid('0101011121', for_region=nhs_number.REGION_SCOTLAND, sex="female")
+nhs_number.is_valid('0101011121', for_region=nhs_number.REGION_SCOTLAND, sex=nhs_number.Sex.FEMALE)
 # True
 
-nhs_number.is_valid('0101011113', sex="male")
+nhs_number.is_valid('0101011113', sex=nhs_number.Sex.MALE)
 # True
 
 # Ignores sex when supplied with non CHI numbers
+male = nhs_number.Sex.MALE
+
 patients = {
-    1: {"identifier": "4698194180", "sex": "male"},
-    2: {"identifier": "0101011113", "sex": "male"},
-    3: {"identifier": "0101011121", "sex": "male"},
+    1: {"identifier": "4698194180", "sex": male},
+    2: {"identifier": "0101011113", "sex": male},
+    3: {"identifier": "0101011121", "sex": male},
 }
 
 for patient_info in patients.values():

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,6 +19,7 @@ Returns `False` if the NHS Number is not valid.
       - `123-456-7890`
       - `1234567890`
 - `for_region` (*optional, default=None, `Region`*): If provided, additionally validates number is included within the given [`Region`](#regions) range.
+- `sex` (*optional, default=None, `str`*): If provided and the number is in the Scottish range will check if the identifying digit matches the supplied label. Excepted options are `male` or `female`.
 
 ```python
 import nhs_number
@@ -37,9 +38,32 @@ nhs_number.is_valid('7709030025', for_region=nhs_number.REGION_ENGLAND)
 # True
 ```
 
---8<--
-docs/_assets/_snippets/scottish-chi-number.md
---8<--
+The `sex` parameter takes either `male` or `female` and can be used to add additional checks for CHI numbers. Supplying a region is optional which is useful if you want to check for the identified sex when dealing with mixed region numbers. For anything other than CHI this is ignored even if supplied.
+
+```python
+
+nhs_number.is_valid('0101011121', for_region=nhs_number.REGION_SCOTLAND, sex="female")
+# True
+
+nhs_number.is_valid('0101011113', sex="male")
+# True
+
+# Ignores sex when supplied with non CHI numbers
+patients = {
+    1: {"identifier": "4698194180", "sex": "male"},
+    2: {"identifier": "0101011113", "sex": "male"},
+    3: {"identifier": "0101011121", "sex": "male"},
+}
+
+for patient_info in patients.values():
+    identifier = patient_info["identifier"]
+    sex = patient_info["sex"]
+    nhs_number.is_valid(identifier, sex=sex)
+# True
+# True
+# False
+
+```
 
 ## `normalise_number()`
 
@@ -131,8 +155,4 @@ Each Region has some aliases for ease of use:
 nhs_number.ENGLAND_WALES_IOM == nhs_number.REGION_ENGLAND
 # True
 ```
-
---8<--
-docs/_assets/_snippets/scottish-chi-number.md
---8<--
 

--- a/nhs_number/__init__.py
+++ b/nhs_number/__init__.py
@@ -23,8 +23,8 @@ from nhs_number.constants import (
     REGION_SYNTHETIC,
     REGION_EIRE,
 )
-from nhs_number.constants import FULL_RANGE
+from nhs_number.constants import FULL_RANGE, RANGE_NOT_ISSUED_SYNTHETIC
 from nhs_number.details import NhsNumber
-from nhs_number.generate import generate
+from nhs_number.generate import generate, random_chi_str
 from nhs_number.standardise import standardise_format, normalise_number
 from nhs_number.validate import is_valid, calculate_checksum

--- a/nhs_number/__init__.py
+++ b/nhs_number/__init__.py
@@ -24,6 +24,7 @@ from nhs_number.constants import (
     REGION_EIRE,
 )
 from nhs_number.constants import FULL_RANGE, RANGE_NOT_ISSUED_SYNTHETIC
+from nhs_number.constants import Sex
 from nhs_number.details import NhsNumber
 from nhs_number.generate import generate, random_chi_str
 from nhs_number.standardise import standardise_format, normalise_number

--- a/nhs_number/constants.py
+++ b/nhs_number/constants.py
@@ -25,6 +25,8 @@ Ranges are INCLUSIVE of the start and end values.
     9000000000 - 9999999999 Not to be issued (Synthetic/test patients PDS)
 """
 
+from enum import Enum
+
 
 # using dataclasses would force Python 3.7 or above so we'll use a simple
 # class instead
@@ -67,6 +69,11 @@ class Region:
             if _range.contains_number(number):
                 return True
         return False
+
+
+class Sex(Enum):
+    MALE = "MALE"
+    FEMALE = "FEMALE"
 
 
 RANGE_UNALLOCATED_1 = Range(

--- a/nhs_number/constants.py
+++ b/nhs_number/constants.py
@@ -72,8 +72,8 @@ class Region:
 
 
 class Sex(Enum):
-    MALE = "MALE"
-    FEMALE = "FEMALE"
+    MALE = 1
+    FEMALE = 2
 
 
 RANGE_UNALLOCATED_1 = Range(

--- a/nhs_number/validate.py
+++ b/nhs_number/validate.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from nhs_number.standardise import standardise_format
 from nhs_number.constants import Region, REGION_SCOTLAND
 
+import warnings
+
 
 def calculate_checksum(identifier_digits: str) -> int | None:
     """
@@ -79,6 +81,10 @@ def is_valid(
             return False
 
         if sex:
+            if sex.lower() not in ("female", "male"):
+                warnings.warn(
+                    "Sex value supplied not male or female. Ignoring sex check"
+                )
             if int(nhs_number[8]) % 2 == 0 and sex.lower() == "male":
                 return False
 

--- a/nhs_number/validate.py
+++ b/nhs_number/validate.py
@@ -15,7 +15,7 @@ from __future__ import (
 )  # for Python 3.7 (remove once we stop supporting 3.7)
 from datetime import datetime
 from nhs_number.standardise import standardise_format
-from nhs_number.constants import Region, REGION_SCOTLAND
+from nhs_number.constants import Region, REGION_SCOTLAND, Sex
 
 import warnings
 
@@ -44,10 +44,7 @@ def calculate_checksum(identifier_digits: str) -> int | None:
 
 
 def is_valid(
-    nhs_number: str,
-    for_region: Region = None,
-    is_male: bool = False,
-    is_female: bool = False,
+    nhs_number: str, for_region: Region = None, sex: Sex = None
 ) -> bool:
     """
     Checks the supplied NHS number (as a string) is valid and returns True
@@ -83,14 +80,16 @@ def is_valid(
         except ValueError:
             return False
 
-        if is_male and is_female:
-            warnings.warn("Select male or female not both. Ignoring sex check")
+        if sex and not isinstance(sex, Sex):
+            warnings.warn(
+                "Sex argument must be of type Sex. Ignoring sex check"
+            )
 
-        else:
-            if int(nhs_number[8]) % 2 == 0 and is_male:
+        if sex and isinstance(sex, Sex):
+            if int(nhs_number[8]) % 2 == 0 and sex == Sex.MALE:
                 return False
 
-            if int(nhs_number[8]) % 2 != 0 and is_female:
+            if int(nhs_number[8]) % 2 != 0 and sex == Sex.FEMALE:
                 return False
 
     # Test for checksum validity

--- a/nhs_number/validate.py
+++ b/nhs_number/validate.py
@@ -44,7 +44,10 @@ def calculate_checksum(identifier_digits: str) -> int | None:
 
 
 def is_valid(
-    nhs_number: str, for_region: Region = None, sex: str = None
+    nhs_number: str,
+    for_region: Region = None,
+    is_male: bool = False,
+    is_female: bool = False,
 ) -> bool:
     """
     Checks the supplied NHS number (as a string) is valid and returns True
@@ -80,16 +83,11 @@ def is_valid(
         except ValueError:
             return False
 
-        if sex:
-            if sex.lower() not in ("female", "male"):
-                warnings.warn(
-                    "Sex value supplied not male or female. Ignoring sex check"
-                )
-            if int(nhs_number[8]) % 2 == 0 and sex.lower() == "male":
-                return False
+        if int(nhs_number[8]) % 2 == 0 and is_male:
+            return False
 
-            if int(nhs_number[8]) % 2 != 0 and sex.lower() == "female":
-                return False
+        if int(nhs_number[8]) % 2 != 0 and is_female:
+            return False
 
     # Test for checksum validity
     # The first 9 numbers are used to calculate the checksum, which should

--- a/nhs_number/validate.py
+++ b/nhs_number/validate.py
@@ -83,11 +83,15 @@ def is_valid(
         except ValueError:
             return False
 
-        if int(nhs_number[8]) % 2 == 0 and is_male:
-            return False
+        if is_male and is_female:
+            warnings.warn("Select male or female not both. Ignoring sex check")
 
-        if int(nhs_number[8]) % 2 != 0 and is_female:
-            return False
+        else:
+            if int(nhs_number[8]) % 2 == 0 and is_male:
+                return False
+
+            if int(nhs_number[8]) % 2 != 0 and is_female:
+                return False
 
     # Test for checksum validity
     # The first 9 numbers are used to calculate the checksum, which should

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nhs-number"
-version = "1.3.10"
+version = "1.4.0"
 description = "Python package to provide utilities for NHS Numbers, including validity checks, normalisation, and generation."
 authors = [
     "Andy Law <andy.law@roslin.ed.ac.uk>",

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,7 +1,17 @@
 import pytest
 
+from datetime import datetime
 
-from nhs_number import generate, is_valid, REGION_ENGLAND_WALES_IOM
+
+from nhs_number import (
+    generate,
+    random_chi_str,
+    is_valid,
+    REGION_ENGLAND_WALES_IOM,
+    REGION_SCOTLAND,
+    REGION_NORTHERN_IRELAND,
+    REGION_SYNTHETIC,
+)
 
 
 def test_create_valid_nhs_number():
@@ -42,7 +52,14 @@ def test_random_nhs_numbers():
         assert is_valid(nhs_number)
 
 
-def test_nhs_numbers_for_a_specific_region():
+def test_nhs_numbers_with_no_region():
+    nhs_numbers = generate()
+    assert len(nhs_numbers) == 1
+    assert is_valid(nhs_numbers[0])
+    assert REGION_SYNTHETIC.contains_number(nhs_numbers[0])
+
+
+def test_nhs_numbers_for_specific_regions():
     """
     Test that NHS numbers for a specific region are generated
     """
@@ -50,6 +67,16 @@ def test_nhs_numbers_for_a_specific_region():
     assert len(nhs_numbers) == 1
     assert is_valid(nhs_numbers[0])
     assert REGION_ENGLAND_WALES_IOM.contains_number(nhs_numbers[0])
+
+    nhs_numbers = generate(for_region=REGION_SCOTLAND)
+    assert len(nhs_numbers) == 1
+    assert is_valid(nhs_numbers[0])
+    assert REGION_SCOTLAND.contains_number(nhs_numbers[0])
+
+    nhs_numbers = generate(for_region=REGION_NORTHERN_IRELAND)
+    assert len(nhs_numbers) == 1
+    assert is_valid(nhs_numbers[0])
+    assert REGION_NORTHERN_IRELAND.contains_number(nhs_numbers[0])
 
 
 def test_fail_when_non_region_supplied():
@@ -61,3 +88,16 @@ def test_fail_when_non_region_supplied():
     with pytest.raises(TypeError) as error:
         # noinspection PyTypeChecker
         nhs_numbers = generate(for_region="REGION_ENGLAND_WALES_IOM")
+
+
+def test_random_chi_str_len():
+    partial_chi_number = random_chi_str()
+    assert len(partial_chi_number) == 9
+
+
+def test_random_chi_str_is_real_date():
+    partial_chi_number = random_chi_str()
+    try:
+        datetime.strptime(partial_chi_number[:6], "%d%m%y")
+    except ValueError as e:
+        pytest.fail(f"Unexpected ValueError: {e}")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -75,7 +75,7 @@ def test_warning_if_not_sex_type_given():
 
 
 def test_nhs_pass_when_sex_supplied_thing():
-    assert is_valid("0101011113", sex="female") is True
+    assert is_valid("0101011113", sex=Sex.FEMALE) is True
 
 
 def test_valid_england_wales_number():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -73,10 +73,6 @@ def test_warning_if_not_sex_type_given():
         is_valid("0101011113", sex="female")
 
 
-def test_nhs_pass_when_sex_supplied_thing():
-    assert is_valid("0101011113", sex=Sex.FEMALE) is True
-
-
 def test_valid_england_wales_number():
     assert is_valid("4000000632", for_region=REGION_ENGLAND_WALES_IOM) is True
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -64,6 +64,11 @@ def test_chi_incorrect_sex_female():
     assert is_valid("0101011113", is_female=True) is False
 
 
+def test_warning_if_both_male_and_female():
+    with pytest.warns(UserWarning, match="Select male or female not both"):
+        is_valid("0101011113", is_male=True, is_female=True)
+
+
 def test_nhs_pass_when_sex_supplied():
     assert is_valid("4000000632", is_female=True) is True
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2,7 +2,6 @@ from nhs_number import is_valid, calculate_checksum
 from nhs_number import REGION_ENGLAND_WALES_IOM, REGION_SCOTLAND
 from nhs_number import Sex
 import pytest
-import warnings
 
 
 def test_string_is_valid_good_one():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,6 @@
 from nhs_number import is_valid, calculate_checksum
 from nhs_number import REGION_ENGLAND_WALES_IOM, REGION_SCOTLAND
+from nhs_number import Sex
 import pytest
 import warnings
 
@@ -49,28 +50,32 @@ def test_chi_impossible_date_no_region():
 
 
 def test_chi_correct_sex_male():
-    assert is_valid("0101011113", is_male=True) is True
+    assert is_valid("0101011113", sex=Sex.MALE) is True
 
 
 def test_chi_incorrect_sex_male():
-    assert is_valid("0101011121", is_male=True) is False
+    assert is_valid("0101011121", sex=Sex.MALE) is False
 
 
 def test_chi_correct_sex_female():
-    assert is_valid("0101011121", is_female=True) is True
+    assert is_valid("0101011121", sex=Sex.FEMALE) is True
 
 
 def test_chi_incorrect_sex_female():
-    assert is_valid("0101011113", is_female=True) is False
-
-
-def test_warning_if_both_male_and_female():
-    with pytest.warns(UserWarning, match="Select male or female not both"):
-        is_valid("0101011113", is_male=True, is_female=True)
+    assert is_valid("0101011113", sex=Sex.FEMALE) is False
 
 
 def test_nhs_pass_when_sex_supplied():
-    assert is_valid("4000000632", is_female=True) is True
+    assert is_valid("4000000632", sex=Sex.FEMALE) is True
+
+
+def test_warning_if_not_sex_type_given():
+    with pytest.warns(UserWarning, match="Sex argument must be of type Sex"):
+        is_valid("0101011113", sex="female")
+
+
+def test_nhs_pass_when_sex_supplied_thing():
+    assert is_valid("0101011113", sex="female") is True
 
 
 def test_valid_england_wales_number():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,5 @@
 from nhs_number import is_valid, calculate_checksum
-from nhs_number import REGION_ENGLAND_WALES_IOM
+from nhs_number import REGION_ENGLAND_WALES_IOM, REGION_SCOTLAND
 
 
 def test_string_is_valid_good_one():
@@ -36,6 +36,34 @@ def test_string_is_valid_leading_zero_chi():
 
 def test_int_is_valid_leading_zero_chi():
     assert is_valid(607230002) is True
+
+
+def test_chi_impossible_date():
+    assert is_valid("0113011113", for_region=REGION_SCOTLAND) is False
+
+
+def test_chi_impossible_date_no_region():
+    assert is_valid("0113011113") is False
+
+
+def test_chi_correct_sex_male():
+    assert is_valid("0101011113", sex="male") is True
+
+
+def test_chi_incorrect_sex_male():
+    assert is_valid("0101011121", sex="male") is False
+
+
+def test_chi_correct_sex_female():
+    assert is_valid("0101011121", sex="female") is True
+
+
+def test_chi_incorrect_sex_female():
+    assert is_valid("0101011113", sex="female") is False
+
+
+def test_nhs_pass_when_sex_supplied():
+    assert is_valid("4000000632", sex="female") is True
 
 
 def test_valid_england_wales_number():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,7 @@
 from nhs_number import is_valid, calculate_checksum
 from nhs_number import REGION_ENGLAND_WALES_IOM, REGION_SCOTLAND
 import pytest
+import warnings
 
 
 def test_string_is_valid_good_one():
@@ -73,7 +74,8 @@ def test_bad_sex_option():
 
 
 def test_no_message_bad_sex_option_and_not_chi():
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         is_valid("4000000632", sex="other")
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -49,34 +49,23 @@ def test_chi_impossible_date_no_region():
 
 
 def test_chi_correct_sex_male():
-    assert is_valid("0101011113", sex="male") is True
+    assert is_valid("0101011113", is_male=True) is True
 
 
 def test_chi_incorrect_sex_male():
-    assert is_valid("0101011121", sex="male") is False
+    assert is_valid("0101011121", is_male=True) is False
 
 
 def test_chi_correct_sex_female():
-    assert is_valid("0101011121", sex="female") is True
+    assert is_valid("0101011121", is_female=True) is True
 
 
 def test_chi_incorrect_sex_female():
-    assert is_valid("0101011113", sex="female") is False
+    assert is_valid("0101011113", is_female=True) is False
 
 
 def test_nhs_pass_when_sex_supplied():
-    assert is_valid("4000000632", sex="female") is True
-
-
-def test_bad_sex_option():
-    with pytest.warns():
-        is_valid("0101011113", sex="other")
-
-
-def test_no_message_bad_sex_option_and_not_chi():
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        is_valid("4000000632", sex="other")
+    assert is_valid("4000000632", is_female=True) is True
 
 
 def test_valid_england_wales_number():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,6 @@
 from nhs_number import is_valid, calculate_checksum
 from nhs_number import REGION_ENGLAND_WALES_IOM, REGION_SCOTLAND
+import pytest
 
 
 def test_string_is_valid_good_one():
@@ -64,6 +65,16 @@ def test_chi_incorrect_sex_female():
 
 def test_nhs_pass_when_sex_supplied():
     assert is_valid("4000000632", sex="female") is True
+
+
+def test_bad_sex_option():
+    with pytest.warns():
+        is_valid("0101011113", sex="other")
+
+
+def test_no_message_bad_sex_option_and_not_chi():
+    with pytest.warns(None):
+        is_valid("4000000632", sex="other")
 
 
 def test_valid_england_wales_number():


### PR DESCRIPTION
## Summary

The 2.0 release: full **CHI (Scotland) number validation** plus a safer **`generate()`** default. This **supersedes #38** - it preserves Andy Atterton's commits (via merge) and reworks them to the binary, default-on design agreed in #61 / #25, on top of the 1.4.0 test net from #58.

Resolves #24, #25, #59.

## Breaking changes

- **CHI date-of-birth validation is now default-on and binary.** A number in the Scotland CHI range encodes the date of birth in its first 6 digits as `DDMMYY`; if that segment is not a real calendar date, `is_valid()` and `NhsNumber` now report it invalid. There is no opt-out - a CHI number is either valid or it is not (per the consensus in #61). Previously only checksum + range were checked.
- **`generate()` now defaults to the synthetic / test range** instead of the full range, so a generated number can never be mistaken for a live NHS number (#24). Pass `for_region=` for a specific region; `generate(for_region=REGION_SCOTLAND)` produces CHIs with a valid date of birth.
- **Scotland CHI range boundary corrected (#59):** starts at `100_000_000` (smallest plausible CHI, 01/01/00), not `10_000_000`. Numbers in `10_000_000`-`99_999_999` are now classified as unallocated, not Scotland.

## What changed vs Andy's #38

- **`sex` / `Sex` enum removed**, deferred to a separate PR. Sex parity was an explicit non-goal in the #61 discussion (terminology/presentation sensitivity); 2.0 stays on the agreed date-only scope. Andy's sex implementation is preserved in this branch's history and can be lifted into the follow-up.
- `random_chi_str` and `RANGE_NOT_ISSUED_SYNTHETIC` kept **internal** (not added to the public import surface), consistent with the closed public-API set pinned in #58. **2.0 makes no public-name changes.**
- **#59 fixed here** (Andy's branch didn't) and #58's pinned tripwire tests updated to the corrected values.
- Test suites reconciled: #58's comprehensive tests + grafted CHI/generate tests; Scotland fixtures corrected to date-valid CHIs.

## Tests

- 207 passed, 100% line and branch coverage.
- CHI: valid date accepted; impossible date (e.g. month 13) rejected with and without `for_region`.
- `generate()`: defaults to synthetic range; Scotland generation is date-valid; `random_chi_str` produces real dates.

## Release plan

Branch-based publishing means merging to `main` auto-publishes to PyPI. Plan: smoke-test on `staging` → test.pypi.org first, then merge here to release **2.0.0** to PyPI.

## Credit

CHI validation and generation by @andyatterton (#38). This PR supersedes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
