### PR TITLE
tox + black formatting + CI black check

### DIFF
--- a/.github/workflows/test-all-branches.yml
+++ b/.github/workflows/test-all-branches.yml
@@ -29,3 +29,8 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov=nhs_number --cov-branch --cov-report=term --cov-fail-under=100
+      - name: Check code formatting with black
+        if: matrix.python-version == '3.13'
+        run: |
+          pip install black
+          black --check .

--- a/nhs_number/details.py
+++ b/nhs_number/details.py
@@ -76,7 +76,9 @@ class NhsNumber:
         if standardised:
             self.identifier_digits = standardised[:-1]
             self.check_digit = int(standardised[-1])
-            self.calculated_checksum = calculate_checksum(self.identifier_digits)
+            self.calculated_checksum = calculate_checksum(
+                self.identifier_digits
+            )
             self.valid = is_valid(standardised)
         else:
             self.identifier_digits = ""

--- a/nhs_number/standardise.py
+++ b/nhs_number/standardise.py
@@ -55,6 +55,9 @@ def standardise_format(nhs_number) -> str:
 
 
 def normalise_number(nhs_number: str) -> str:
-    warnings.warn("The normalise_number() function is deprecated - use "
-                  "standardise_format() instead", DeprecationWarning)
+    warnings.warn(
+        "The normalise_number() function is deprecated - use "
+        "standardise_format() instead",
+        DeprecationWarning,
+    )
     return standardise_format(nhs_number)

--- a/nhs_number/validate.py
+++ b/nhs_number/validate.py
@@ -9,6 +9,7 @@ Contributors
 * Andy Law <andy.law@roslin.ed.ac.uk>
 * Marcus Baw <marcus@marcusbaw.com>
 """
+
 # PEP 604 union syntax (`int | None`) is 3.10+; defer annotation evaluation
 # so we keep working on Python 3.8 and 3.9. Remove this once 3.8/3.9 are
 # dropped from the test matrix.
@@ -81,7 +82,7 @@ def is_valid(nhs_number: str, for_region: Region = None) -> bool:
     # Test for checksum validity
     # The first 9 numbers are used to calculate the checksum, which should
     # match the last digit
-    (identifier_digits, check_digit) = (nhs_number[:-1], int(nhs_number[-1]))
+    identifier_digits, check_digit = (nhs_number[:-1], int(nhs_number[-1]))
     calculated_checksum = calculate_checksum(identifier_digits)
     # NOTE: a checksum of 10 is invalid (and is quoted as a special case),
     # but the check for equality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,3 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 79
-experimental-string-processing = true

--- a/tests/test_bulk_validation.py
+++ b/tests/test_bulk_validation.py
@@ -9,6 +9,7 @@ If someone runs the suite without the dataset present (e.g. a sparse
 checkout), the test skips with a pointer rather than failing — but the
 default expectation is that it runs.
 """
+
 import csv
 import os.path
 import sys
@@ -16,7 +17,6 @@ import sys
 import pytest
 
 from nhs_number import is_valid
-
 
 csv.field_size_limit(sys.maxsize)
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -10,6 +10,7 @@ release to agree with the module docstring and the CHI specification: the
 Scotland CHI range starts at 100_000_000 (the smallest plausible CHI,
 01/01/00), not 10_000_000 - see issue #59.
 """
+
 import pytest
 
 from nhs_number.constants import (
@@ -39,20 +40,29 @@ from nhs_number.constants import (
     REGION_IOM,
 )
 
-
 # (name, range_obj, start, end) — order matches the documented sequence in
 # constants.py so the non-overlap test below sweeps boundaries in order.
 ALL_RANGES = [
-    ("UNALLOCATED_1",       RANGE_UNALLOCATED_1,        10,            99_999_999),
-    ("SCOTLAND",            RANGE_SCOTLAND,             100_000_000,   3_112_999_999),
-    ("UNALLOCATED_2",       RANGE_UNALLOCATED_2,        3_113_000_000, 3_199_999_999),
-    ("NORTHERN_IRELAND",    RANGE_NORTHERN_IRELAND,     3_200_000_000, 3_999_999_999),
-    ("ENGLAND_WALES_IOM_1", RANGE_ENGLAND_WALES_IOM_1,  4_000_000_000, 4_999_999_999),
-    ("RESERVED",            RANGE_RESERVED,             5_000_000_000, 5_999_999_999),
-    ("ENGLAND_WALES_IOM_2", RANGE_ENGLAND_WALES_IOM_2,  6_000_000_000, 7_999_999_999),
-    ("EIRE",                RANGE_EIRE,                 8_000_000_000, 8_599_999_999),
-    ("UNALLOCATED_3",       RANGE_UNALLOCATED_3,        8_600_000_000, 8_999_999_999),
-    ("SYNTHETIC",           RANGE_NOT_ISSUED_SYNTHETIC, 9_000_000_000, 9_999_999_999),
+    ("UNALLOCATED_1", RANGE_UNALLOCATED_1, 10, 99_999_999),
+    ("SCOTLAND", RANGE_SCOTLAND, 100_000_000, 3_112_999_999),
+    ("UNALLOCATED_2", RANGE_UNALLOCATED_2, 3_113_000_000, 3_199_999_999),
+    ("NORTHERN_IRELAND", RANGE_NORTHERN_IRELAND, 3_200_000_000, 3_999_999_999),
+    (
+        "ENGLAND_WALES_IOM_1",
+        RANGE_ENGLAND_WALES_IOM_1,
+        4_000_000_000,
+        4_999_999_999,
+    ),
+    ("RESERVED", RANGE_RESERVED, 5_000_000_000, 5_999_999_999),
+    (
+        "ENGLAND_WALES_IOM_2",
+        RANGE_ENGLAND_WALES_IOM_2,
+        6_000_000_000,
+        7_999_999_999,
+    ),
+    ("EIRE", RANGE_EIRE, 8_000_000_000, 8_599_999_999),
+    ("UNALLOCATED_3", RANGE_UNALLOCATED_3, 8_600_000_000, 8_999_999_999),
+    ("SYNTHETIC", RANGE_NOT_ISSUED_SYNTHETIC, 9_000_000_000, 9_999_999_999),
 ]
 
 _RANGE_IDS = [r[0] for r in ALL_RANGES]
@@ -61,6 +71,7 @@ _RANGE_IDS = [r[0] for r in ALL_RANGES]
 # ---------------------------------------------------------------------------
 # Pinned start/end values
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("name,rng,start,end", ALL_RANGES, ids=_RANGE_IDS)
 def test_range_pinned_boundaries(name, rng, start, end):
@@ -72,6 +83,7 @@ def test_range_pinned_boundaries(name, rng, start, end):
 # ---------------------------------------------------------------------------
 # Inclusivity at boundaries
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("name,rng,start,end", ALL_RANGES, ids=_RANGE_IDS)
 def test_range_contains_at_boundaries(name, rng, start, end):
@@ -91,6 +103,7 @@ def test_range_excludes_just_outside_boundaries(name, rng, start, end):
 # Range.contains_number accepts both int and string forms
 # ---------------------------------------------------------------------------
 
+
 def test_range_contains_number_accepts_int_and_string():
     """Range.contains_number coerces with int(); both forms must agree."""
     assert RANGE_NORTHERN_IRELAND.contains_number("3500000000") is True
@@ -102,6 +115,7 @@ def test_range_contains_number_accepts_int_and_string():
 # ---------------------------------------------------------------------------
 # FULL_RANGE
 # ---------------------------------------------------------------------------
+
 
 def test_full_range_pinned_and_inclusive():
     assert FULL_RANGE.start == 10
@@ -118,20 +132,30 @@ def test_full_range_pinned_and_inclusive():
 
 # Map each Range to the single Region that should contain its endpoints.
 RANGE_TO_REGION = [
-    ("UNALLOCATED_1",       RANGE_UNALLOCATED_1,        REGION_UNALLOCATED),
-    ("SCOTLAND",            RANGE_SCOTLAND,             REGION_SCOTLAND),
-    ("UNALLOCATED_2",       RANGE_UNALLOCATED_2,        REGION_UNALLOCATED),
-    ("NORTHERN_IRELAND",    RANGE_NORTHERN_IRELAND,     REGION_NORTHERN_IRELAND),
-    ("ENGLAND_WALES_IOM_1", RANGE_ENGLAND_WALES_IOM_1,  REGION_ENGLAND_WALES_IOM),
-    ("RESERVED",            RANGE_RESERVED,             REGION_RESERVED),
-    ("ENGLAND_WALES_IOM_2", RANGE_ENGLAND_WALES_IOM_2,  REGION_ENGLAND_WALES_IOM),
-    ("EIRE",                RANGE_EIRE,                 REGION_EIRE),
-    ("UNALLOCATED_3",       RANGE_UNALLOCATED_3,        REGION_UNALLOCATED),
-    ("SYNTHETIC",           RANGE_NOT_ISSUED_SYNTHETIC, REGION_SYNTHETIC),
+    ("UNALLOCATED_1", RANGE_UNALLOCATED_1, REGION_UNALLOCATED),
+    ("SCOTLAND", RANGE_SCOTLAND, REGION_SCOTLAND),
+    ("UNALLOCATED_2", RANGE_UNALLOCATED_2, REGION_UNALLOCATED),
+    ("NORTHERN_IRELAND", RANGE_NORTHERN_IRELAND, REGION_NORTHERN_IRELAND),
+    (
+        "ENGLAND_WALES_IOM_1",
+        RANGE_ENGLAND_WALES_IOM_1,
+        REGION_ENGLAND_WALES_IOM,
+    ),
+    ("RESERVED", RANGE_RESERVED, REGION_RESERVED),
+    (
+        "ENGLAND_WALES_IOM_2",
+        RANGE_ENGLAND_WALES_IOM_2,
+        REGION_ENGLAND_WALES_IOM,
+    ),
+    ("EIRE", RANGE_EIRE, REGION_EIRE),
+    ("UNALLOCATED_3", RANGE_UNALLOCATED_3, REGION_UNALLOCATED),
+    ("SYNTHETIC", RANGE_NOT_ISSUED_SYNTHETIC, REGION_SYNTHETIC),
 ]
 
 
-@pytest.mark.parametrize("name,rng,region", RANGE_TO_REGION, ids=[r[0] for r in RANGE_TO_REGION])
+@pytest.mark.parametrize(
+    "name,rng,region", RANGE_TO_REGION, ids=[r[0] for r in RANGE_TO_REGION]
+)
 def test_region_contains_each_of_its_ranges_endpoints(name, rng, region):
     assert region.contains_number(rng.start) is True
     assert region.contains_number(rng.end) is True
@@ -173,21 +197,22 @@ def test_regions_are_mutually_exclusive_at_boundaries(name, rng, start, end):
 
 def test_below_full_range_matches_no_region():
     for value in (0, 1, 9):
-        assert _matching_regions(value) == [], (
-            f"value {value} below FULL_RANGE.start matched a region"
-        )
+        assert (
+            _matching_regions(value) == []
+        ), f"value {value} below FULL_RANGE.start matched a region"
 
 
 def test_above_full_range_matches_no_region():
     for value in (10_000_000_000, 99_999_999_999):
-        assert _matching_regions(value) == [], (
-            f"value {value} above FULL_RANGE.end matched a region"
-        )
+        assert (
+            _matching_regions(value) == []
+        ), f"value {value} above FULL_RANGE.end matched a region"
 
 
 # ---------------------------------------------------------------------------
 # Region aliases
 # ---------------------------------------------------------------------------
+
 
 def test_england_wales_iom_aliases_are_the_same_object():
     """REGION_ENGLAND, REGION_WALES, REGION_IOM are aliases for the combined
@@ -202,6 +227,7 @@ def test_england_wales_iom_aliases_are_the_same_object():
 # ---------------------------------------------------------------------------
 # REGIONS dict — public surface
 # ---------------------------------------------------------------------------
+
 
 def test_regions_dict_keys():
     """NhsNumber iterates REGIONS by these handles; pin them as a public API."""
@@ -219,6 +245,7 @@ def test_regions_dict_keys():
 # ---------------------------------------------------------------------------
 # Direct construction of Range and Region (no implicit dependency on globals)
 # ---------------------------------------------------------------------------
+
 
 def test_range_constructor_attributes_and_contains():
     r = Range(start=100, end=200, label="test range")

--- a/tests/test_details.py
+++ b/tests/test_details.py
@@ -23,22 +23,29 @@ def test_valid_synthetic_nhs_number_details():
     assert number.calculated_checksum == 0
     assert isinstance(number.region, Region)
     assert "test" in number.region.tags
-    assert number.region_comment == ("Not to be issued "
-                                     "(Synthetic/test patients PDS)")
+    assert number.region_comment == (
+        "Not to be issued " "(Synthetic/test patients PDS)"
+    )
 
 
 # --- Region coverage: one valid number per region ---------------------------
 
-@pytest.mark.parametrize("nhs_num,expected_region,expected_label_substr", [
-    ("0101011113", REGION_SCOTLAND,          "Scotland"),
-    ("3462950622", REGION_NORTHERN_IRELAND,  "Northern Ireland"),
-    ("4149827702", REGION_ENGLAND_WALES_IOM, "England Wales"),
-    ("5726600533", REGION_RESERVED,          "Reserved"),
-    ("8453035113", REGION_EIRE,              "Republic of Ireland"),
-    ("0000499927", REGION_UNALLOCATED,       "Unallocated"),
-    ("9234760735", REGION_SYNTHETIC,         "Synthetic"),
-])
-def test_nhs_number_region_detection(nhs_num, expected_region, expected_label_substr):
+
+@pytest.mark.parametrize(
+    "nhs_num,expected_region,expected_label_substr",
+    [
+        ("0101011113", REGION_SCOTLAND, "Scotland"),
+        ("3462950622", REGION_NORTHERN_IRELAND, "Northern Ireland"),
+        ("4149827702", REGION_ENGLAND_WALES_IOM, "England Wales"),
+        ("5726600533", REGION_RESERVED, "Reserved"),
+        ("8453035113", REGION_EIRE, "Republic of Ireland"),
+        ("0000499927", REGION_UNALLOCATED, "Unallocated"),
+        ("9234760735", REGION_SYNTHETIC, "Synthetic"),
+    ],
+)
+def test_nhs_number_region_detection(
+    nhs_num, expected_region, expected_label_substr
+):
     n = NhsNumber(nhs_num)
     assert n.nhs_number == nhs_num
     assert n.identifier_digits == nhs_num[:-1]
@@ -51,6 +58,7 @@ def test_nhs_number_region_detection(nhs_num, expected_region, expected_label_su
 
 
 # --- Latent bug: out-of-all-ranges input ------------------------------------
+
 
 def test_nhs_number_below_all_regions_has_no_region():
     """Numbers below FULL_RANGE.start (10) match no region.
@@ -67,11 +75,15 @@ def test_nhs_number_below_all_regions_has_no_region():
 
 # --- Input parsing: formatted strings ---------------------------------------
 
-@pytest.mark.parametrize("formatted", [
-    "987 654 3210",
-    "987-654-3210",
-    "  9876543210  ",
-])
+
+@pytest.mark.parametrize(
+    "formatted",
+    [
+        "987 654 3210",
+        "987-654-3210",
+        "  9876543210  ",
+    ],
+)
 def test_nhs_number_accepts_formatted_input(formatted):
     n = NhsNumber(formatted)
     assert n.identifier_digits == "987654321"
@@ -81,6 +93,7 @@ def test_nhs_number_accepts_formatted_input(formatted):
 
 
 # --- Input parsing: int -----------------------------------------------------
+
 
 def test_nhs_number_accepts_int_input():
     n = NhsNumber(9876543210)
@@ -92,7 +105,10 @@ def test_nhs_number_accepts_int_input():
 
 # --- Garbage / empty / None: construct cleanly, valid=False -----------------
 
-@pytest.mark.parametrize("bad_input", ["", "   ", "abcdefghij", "987654321X", None])
+
+@pytest.mark.parametrize(
+    "bad_input", ["", "   ", "abcdefghij", "987654321X", None]
+)
 def test_nhs_number_invalid_input_constructs_cleanly(bad_input):
     n = NhsNumber(bad_input)
     assert n.valid is False

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -77,6 +77,7 @@ def test_fail_when_non_region_supplied():
 # Quantity edge cases
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize("quantity", [0, -1, -100])
 def test_generate_zero_or_negative_quantity_returns_empty(quantity):
     """The while-loop guard ``len(numbers) < quantity`` means zero and
@@ -97,18 +98,22 @@ def test_generate_returns_exact_quantity(quantity):
 # ---------------------------------------------------------------------------
 
 ALL_REGIONS = [
-    ("SCOTLAND",          REGION_SCOTLAND),
-    ("NORTHERN_IRELAND",  REGION_NORTHERN_IRELAND),
+    ("SCOTLAND", REGION_SCOTLAND),
+    ("NORTHERN_IRELAND", REGION_NORTHERN_IRELAND),
     ("ENGLAND_WALES_IOM", REGION_ENGLAND_WALES_IOM),
-    ("RESERVED",          REGION_RESERVED),
-    ("EIRE",              REGION_EIRE),
-    ("UNALLOCATED",       REGION_UNALLOCATED),
-    ("SYNTHETIC",         REGION_SYNTHETIC),
+    ("RESERVED", REGION_RESERVED),
+    ("EIRE", REGION_EIRE),
+    ("UNALLOCATED", REGION_UNALLOCATED),
+    ("SYNTHETIC", REGION_SYNTHETIC),
 ]
 
 
-@pytest.mark.parametrize("name,region", ALL_REGIONS, ids=[r[0] for r in ALL_REGIONS])
-def test_generate_valid_for_region_yields_in_region_valid_numbers(name, region):
+@pytest.mark.parametrize(
+    "name,region", ALL_REGIONS, ids=[r[0] for r in ALL_REGIONS]
+)
+def test_generate_valid_for_region_yields_in_region_valid_numbers(
+    name, region
+):
     """For every Region, a batch of generate(valid=True, for_region=...) must
     produce numbers that are (a) checksum-valid and (b) inside the region.
     """
@@ -119,8 +124,12 @@ def test_generate_valid_for_region_yields_in_region_valid_numbers(name, region):
         assert region.contains_number(n), f"{n} not in region {name}"
 
 
-@pytest.mark.parametrize("name,region", ALL_REGIONS, ids=[r[0] for r in ALL_REGIONS])
-def test_generate_invalid_for_region_yields_in_region_invalid_numbers(name, region):
+@pytest.mark.parametrize(
+    "name,region", ALL_REGIONS, ids=[r[0] for r in ALL_REGIONS]
+)
+def test_generate_invalid_for_region_yields_in_region_invalid_numbers(
+    name, region
+):
     """generate(valid=False, for_region=...) is an "in-region but checksum-
     invalid" generator — the number should still fall inside the requested
     region's ranges. Pins the cross-cutting invariant that ``valid`` only
@@ -136,6 +145,7 @@ def test_generate_invalid_for_region_yields_in_region_invalid_numbers(name, regi
 # ---------------------------------------------------------------------------
 # valid=False at scale
 # ---------------------------------------------------------------------------
+
 
 def test_generate_invalid_at_scale_all_invalid():
     """Pin that generate(valid=False, quantity=N) never sneaks a checksum-
@@ -154,6 +164,7 @@ def test_generate_invalid_at_scale_all_invalid():
 # NHS number. This is a breaking change from the previous FULL_RANGE default.
 # ---------------------------------------------------------------------------
 
+
 def test_generate_default_is_synthetic_range():
     for n in generate(quantity=100):
         assert REGION_SYNTHETIC.contains_number(n), (
@@ -166,6 +177,7 @@ def test_generate_default_is_synthetic_range():
 # random_chi_str - the internal CHI body generator used for Scotland.
 # Produces nine digits (DDMMYY + serial) whose date segment is a real date.
 # ---------------------------------------------------------------------------
+
 
 def test_random_chi_str_is_nine_digits():
     assert len(random_chi_str()) == 9

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -5,9 +5,9 @@ If a name is removed or renamed accidentally — or if a new public name is
 added without consideration — this test fires. Adding to PUBLIC_NAMES is a
 deliberate decision; removing is a breaking-change decision.
 """
+
 import nhs_number
 from nhs_number.constants import Range
-
 
 PUBLIC_NAMES = [
     # Constants module
@@ -56,7 +56,8 @@ def test_top_level_import_does_not_expose_private_names():
     import types
 
     public_attrs = {
-        name for name in dir(nhs_number)
+        name
+        for name in dir(nhs_number)
         if not name.startswith("_")
         and not isinstance(getattr(nhs_number, name), types.ModuleType)
     }
@@ -99,6 +100,6 @@ def test_public_constants_are_correct_types():
         "REGION_SYNTHETIC",
         "REGION_EIRE",
     ]:
-        assert isinstance(getattr(nhs_number, name), nhs_number.Region), (
-            f"{name} is not a Region instance"
-        )
+        assert isinstance(
+            getattr(nhs_number, name), nhs_number.Region
+        ), f"{name} is not a Region instance"

--- a/tests/test_standardise.py
+++ b/tests/test_standardise.py
@@ -139,18 +139,22 @@ def test_normalise_deprecated():
 # Defensive handling of unsupported input types
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("bad_input", [
-    None,
-    3.14,
-    -1.0,
-    [],
-    {},
-    set(),
-    (1, 2, 3),
-    object(),
-    True,            # bool is a subclass of int but never a meaningful NHS num
-    False,
-])
+
+@pytest.mark.parametrize(
+    "bad_input",
+    [
+        None,
+        3.14,
+        -1.0,
+        [],
+        {},
+        set(),
+        (1, 2, 3),
+        object(),
+        True,  # bool is a subclass of int but never a meaningful NHS num
+        False,
+    ],
+)
 def test_format_unsupported_types_return_empty_string(bad_input):
     """Unsupported input types must return "" rather than raising.
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -74,25 +74,35 @@ def test_checksum_returns_none_if_more_than_nine_digits():
 #   ``region`` (used to assert for_region rejects numbers outside the region
 #   even though their checksum is fine)
 REGION_CASES = [
-    ("SCOTLAND",         REGION_SCOTLAND,         "0101011113", "9876543210"),
+    ("SCOTLAND", REGION_SCOTLAND, "0101011113", "9876543210"),
     ("NORTHERN_IRELAND", REGION_NORTHERN_IRELAND, "3462950622", "9876543210"),
-    ("ENGLAND_WALES",    REGION_ENGLAND_WALES_IOM, "4149827702", "9876543210"),
-    ("RESERVED",         REGION_RESERVED,         "5726600533", "9876543210"),
-    ("EIRE",             REGION_EIRE,             "8453035113", "9876543210"),
-    ("UNALLOCATED",      REGION_UNALLOCATED,      "0000499927", "9876543210"),
-    ("SYNTHETIC",        REGION_SYNTHETIC,        "9234760735", "0101011113"),
+    ("ENGLAND_WALES", REGION_ENGLAND_WALES_IOM, "4149827702", "9876543210"),
+    ("RESERVED", REGION_RESERVED, "5726600533", "9876543210"),
+    ("EIRE", REGION_EIRE, "8453035113", "9876543210"),
+    ("UNALLOCATED", REGION_UNALLOCATED, "0000499927", "9876543210"),
+    ("SYNTHETIC", REGION_SYNTHETIC, "9234760735", "0101011113"),
 ]
 
 
-@pytest.mark.parametrize("name,region,in_range,out_of_range", REGION_CASES,
-                         ids=[c[0] for c in REGION_CASES])
-def test_is_valid_for_region_accepts_in_range_numbers(name, region, in_range, out_of_range):
+@pytest.mark.parametrize(
+    "name,region,in_range,out_of_range",
+    REGION_CASES,
+    ids=[c[0] for c in REGION_CASES],
+)
+def test_is_valid_for_region_accepts_in_range_numbers(
+    name, region, in_range, out_of_range
+):
     assert is_valid(in_range, for_region=region) is True
 
 
-@pytest.mark.parametrize("name,region,in_range,out_of_range", REGION_CASES,
-                         ids=[c[0] for c in REGION_CASES])
-def test_is_valid_for_region_rejects_out_of_range_numbers(name, region, in_range, out_of_range):
+@pytest.mark.parametrize(
+    "name,region,in_range,out_of_range",
+    REGION_CASES,
+    ids=[c[0] for c in REGION_CASES],
+)
+def test_is_valid_for_region_rejects_out_of_range_numbers(
+    name, region, in_range, out_of_range
+):
     """Even with a valid checksum, a number outside ``region`` must be False."""
     # Sanity: the out-of-range fixture itself must have a valid checksum
     # (otherwise the test would pass for the wrong reason).
@@ -106,6 +116,7 @@ def test_is_valid_for_region_rejects_out_of_range_numbers(name, region, in_range
 # A number in the Scotland CHI range whose date segment is not a real
 # calendar date is invalid, regardless of checksum. Applied by default.
 # ---------------------------------------------------------------------------
+
 
 def test_chi_valid_date_is_accepted():
     # 01/01/01 (1 Jan 2001), valid checksum, in the Scotland CHI range
@@ -127,6 +138,7 @@ def test_chi_impossible_date_rejected_by_default():
 # Checksum == 10 (special case noted in validate.py)
 # ---------------------------------------------------------------------------
 
+
 def test_calculate_checksum_can_return_10():
     """For some 9-digit identifiers the formula yields 10. validate.py
     relies on the equality check (10 != any single digit) to mark such
@@ -140,7 +152,9 @@ def test_calculate_checksum_can_return_10():
 
 
 @pytest.mark.parametrize("check_digit", list(range(10)))
-def test_is_valid_rejects_every_check_digit_when_real_checksum_is_10(check_digit):
+def test_is_valid_rejects_every_check_digit_when_real_checksum_is_10(
+    check_digit,
+):
     """When the real checksum is 10, NO single-digit check digit can match,
     so every candidate full number must be rejected.
 
@@ -157,23 +171,27 @@ def test_is_valid_rejects_every_check_digit_when_real_checksum_is_10(check_digit
 # Input-type robustness — is_valid never raises
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("bad_input", [
-    None,
-    "",
-    "   ",
-    "abc",
-    "987654321X",
-    3.14,
-    -1.0,
-    -1,
-    -1234567890,
-    99_999_999_999,    # > 10 digits, zfill is a no-op so format regex fails
-    [],
-    {},
-    object(),
-    True,
-    False,
-])
+
+@pytest.mark.parametrize(
+    "bad_input",
+    [
+        None,
+        "",
+        "   ",
+        "abc",
+        "987654321X",
+        3.14,
+        -1.0,
+        -1,
+        -1234567890,
+        99_999_999_999,  # > 10 digits, zfill is a no-op so format regex fails
+        [],
+        {},
+        object(),
+        True,
+        False,
+    ],
+)
 def test_is_valid_returns_false_for_unparseable_input(bad_input):
     """is_valid must never raise — anything it can't standardise is False."""
     assert is_valid(bad_input) is False

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+isolated_build = true
+envlist = black, py{38,39,310,311,312,313,314}
+skip_missing_interpreters = true
+
+[testenv]
+description = Run the test suite with coverage
+deps =
+    pytest
+    pytest-cov
+commands = pytest --cov=nhs_number --cov-branch --cov-fail-under=100
+
+[testenv:black]
+description = Check code formatting with Black
+skip_install = true
+deps = black
+commands = black --check .


### PR DESCRIPTION
## Summary

Reworks **#39** (tox support) on top of `main` (2.0.0). The original #39's 2024 black pass was stale and conflicting, so this is a fresh take that supersedes it.

Resolves #40.

## Changes

- **Applies black formatting** across all modules and tests at the configured line length of 79. Pure formatting - 207 tests pass at 100% line and branch coverage. Also drops the `experimental-string-processing` key from `[tool.black]`, which modern black rejects.
- **Adds `tox.ini`**: runs the suite across `py38`-`py314` (skipping missing interpreters) plus a `black` environment that checks formatting.
- **Adds a `black --check` CI step** to the test workflow, gated to the 3.13 matrix job so it runs once. The black config and dev dependency already existed in `pyproject.toml`.

## Notes

- The CI black check is a `run:` step on the existing job, so **no new GitHub Actions were introduced**. The repo's existing actions are tag-pinned (e.g. `actions/checkout@v7`); SHA-pinning them all would be a worthwhile separate hygiene pass.

## Credit

tox support originally proposed by @andyatterton (#39 / #40). This PR supersedes #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
