### PR TITLE
Add language-agnostic test vectors for cross-language port parity

### DIFF
--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -1,0 +1,114 @@
+"""
+Language-agnostic behavioural test vectors, run against this (reference)
+implementation.
+
+The vectors in ``tests/vectors/nhs_number_cases.json`` are frozen expected
+results. This harness asserts the Python implementation still matches them,
+so any behaviour change is caught here. The same JSON is intended to be
+consumed verbatim by ports in other languages (e.g. the Rust crate in
+``../nhs-number-rs``) so the implementations stay in lockstep.
+
+Python-specific type-robustness cases (None, lists, objects, floats) are not
+in the shared vectors - they live in the native test files, because they are
+not expressible across languages.
+"""
+
+import json
+import pathlib
+
+import pytest
+
+import nhs_number
+from nhs_number import (
+    NhsNumber,
+    calculate_checksum,
+    is_valid,
+    standardise_format,
+)
+from nhs_number.constants import (
+    RANGE_NORTHERN_IRELAND,
+    RANGE_NOT_ISSUED_SYNTHETIC,
+    RANGE_SCOTLAND,
+    RANGE_UNALLOCATED_1,
+)
+
+_VECTORS = json.loads(
+    (
+        pathlib.Path(__file__).parent / "vectors" / "nhs_number_cases.json"
+    ).read_text()
+)
+
+REGION_MAP = {
+    "SCOTLAND": nhs_number.REGION_SCOTLAND,
+    "NORTHERN_IRELAND": nhs_number.REGION_NORTHERN_IRELAND,
+    "ENGLAND_WALES_IOM": nhs_number.REGION_ENGLAND_WALES_IOM,
+    "RESERVED": nhs_number.REGION_RESERVED,
+    "EIRE": nhs_number.REGION_EIRE,
+    "UNALLOCATED": nhs_number.REGION_UNALLOCATED,
+    "SYNTHETIC": nhs_number.REGION_SYNTHETIC,
+}
+
+RANGE_MAP = {
+    "UNALLOCATED_1": RANGE_UNALLOCATED_1,
+    "SCOTLAND": RANGE_SCOTLAND,
+    "NORTHERN_IRELAND": RANGE_NORTHERN_IRELAND,
+    "SYNTHETIC": RANGE_NOT_ISSUED_SYNTHETIC,
+}
+
+
+def _cases(section):
+    return _VECTORS[section]
+
+
+@pytest.mark.parametrize(
+    "case", _cases("calculate_checksum"), ids=lambda c: c["identifier"]
+)
+def test_checksum_vectors(case):
+    assert calculate_checksum(case["identifier"]) == case["checksum"]
+
+
+@pytest.mark.parametrize(
+    "case", _cases("standardise"), ids=lambda c: repr(c["input"])
+)
+def test_standardise_vectors(case):
+    assert standardise_format(case["input"]) == case["output"]
+
+
+@pytest.mark.parametrize(
+    "case", _cases("standardise_from_int"), ids=lambda c: repr(c["input"])
+)
+def test_standardise_from_int_vectors(case):
+    assert standardise_format(case["input"]) == case["output"]
+
+
+@pytest.mark.parametrize(
+    "case", _cases("is_valid"), ids=lambda c: repr(c["input"])
+)
+def test_is_valid_vectors(case):
+    assert is_valid(case["input"]) is case["valid"]
+
+
+@pytest.mark.parametrize(
+    "case",
+    _cases("is_valid_for_region"),
+    ids=lambda c: f'{c["input"]}-{c["region"]}',
+)
+def test_is_valid_for_region_vectors(case):
+    region = REGION_MAP[case["region"]]
+    assert is_valid(case["input"], for_region=region) is case["valid"]
+
+
+@pytest.mark.parametrize(
+    "case", _cases("region_of"), ids=lambda c: c["number"]
+)
+def test_region_of_vectors(case):
+    assert NhsNumber(case["number"]).region is REGION_MAP[case["region"]]
+
+
+@pytest.mark.parametrize(
+    "case", _cases("range_boundaries"), ids=lambda c: c["range"]
+)
+def test_range_boundary_vectors(case):
+    rng = RANGE_MAP[case["range"]]
+    assert rng.start == case["start"]
+    assert rng.end == case["end"]

--- a/tests/vectors/nhs_number_cases.json
+++ b/tests/vectors/nhs_number_cases.json
@@ -1,54 +1,88 @@
 {
-  "_about": "Language-agnostic behavioural test vectors for nhs-number, frozen against the Python reference implementation (2.0.0). Validated by tests/test_vectors.py, and intended to be consumed verbatim by ports in other languages (e.g. the Rust crate at ../nhs-number-rs) so the implementations stay in lockstep. 'region' names map to the package's REGION_* constants; 'range' names to the RANGE_* constants. Python-specific type-robustness cases (None, lists, objects, floats) live in the native test files, not here, because they are not expressible across languages.",
+  "_about": "Language-agnostic behavioural test vectors for nhs-number, frozen against the Python reference implementation (2.0.0). Validated by tests/test_vectors.py, and intended to be consumed by ports in other languages, so the implementations stay in lockstep. 'region' names map to the package's REGION_* constants; 'range' names to the RANGE_* constants. Python-specific type-robustness cases (None, lists, objects, floats) live in the native test files, not here, because they are not expressible across languages.",
   "calculate_checksum": [
-    {"identifier": "987654321", "checksum": 0},
-    {"identifier": "400000063", "checksum": 2},
-    {"identifier": "000000006", "checksum": 10, "note": "checksum 10 means no single check digit can match - any number with this identifier is invalid"},
-    {"identifier": "12345", "checksum": null, "note": "fewer than 9 digits"},
-    {"identifier": "1234567890123", "checksum": null, "note": "more than 9 digits"}
+    { "identifier": "987654321", "checksum": 0 },
+    { "identifier": "400000063", "checksum": 2 },
+    {
+      "identifier": "000000006",
+      "checksum": 10,
+      "note": "checksum 10 means no single check digit can match - any number with this identifier is invalid"
+    },
+    { "identifier": "12345", "checksum": null, "note": "fewer than 9 digits" },
+    {
+      "identifier": "1234567890123",
+      "checksum": null,
+      "note": "more than 9 digits"
+    }
   ],
   "standardise": [
-    {"input": "9876543210", "output": "9876543210"},
-    {"input": "987 654 3210", "output": "9876543210"},
-    {"input": "987-654-3210", "output": "9876543210"},
-    {"input": "  9876543210  ", "output": "9876543210"},
-    {"input": "", "output": ""},
-    {"input": "abcdefghij", "output": ""},
-    {"input": "987654321X", "output": "", "note": "non-digit character"}
+    { "input": "9876543210", "output": "9876543210" },
+    { "input": "987 654 3210", "output": "9876543210" },
+    { "input": "987-654-3210", "output": "9876543210" },
+    { "input": "  9876543210  ", "output": "9876543210" },
+    { "input": "", "output": "" },
+    { "input": "abcdefghij", "output": "" },
+    { "input": "987654321X", "output": "", "note": "non-digit character" }
   ],
   "standardise_from_int": [
-    {"input": 9876543210, "output": "9876543210"},
-    {"input": 0, "output": "0000000000"},
-    {"input": -1, "output": "", "note": "negative"},
-    {"input": 99999999999, "output": "", "note": "more than 10 digits"}
+    { "input": 9876543210, "output": "9876543210" },
+    { "input": 0, "output": "0000000000" },
+    { "input": -1, "output": "", "note": "negative" },
+    { "input": 99999999999, "output": "", "note": "more than 10 digits" }
   ],
   "is_valid": [
-    {"input": "9876543210", "valid": true},
-    {"input": "1234567890", "valid": false},
-    {"input": "0000000000", "valid": true, "note": "checksum-valid; range is not checked without for_region (issue #44)"},
-    {"input": "987 654 3210", "valid": true, "note": "formatted input is standardised first"},
-    {"input": "", "valid": false},
-    {"input": "garbage", "valid": false},
-    {"input": "0101011113", "valid": true, "note": "Scotland CHI, 01/01/01 - a real date"},
-    {"input": "0113011113", "valid": false, "note": "Scotland CHI, month 13 - impossible date; checksum is valid, only the date rejects it"}
+    { "input": "9876543210", "valid": true },
+    { "input": "1234567890", "valid": false },
+    {
+      "input": "0000000000",
+      "valid": true,
+      "note": "checksum-valid; range is not checked without for_region (issue #44)"
+    },
+    {
+      "input": "987 654 3210",
+      "valid": true,
+      "note": "formatted input is standardised first"
+    },
+    { "input": "", "valid": false },
+    { "input": "garbage", "valid": false },
+    {
+      "input": "0101011113",
+      "valid": true,
+      "note": "Scotland CHI, 01/01/01 - a real date"
+    },
+    {
+      "input": "0113011113",
+      "valid": false,
+      "note": "Scotland CHI, month 13 - impossible date; checksum is valid, only the date rejects it"
+    }
   ],
   "is_valid_for_region": [
-    {"input": "0101011113", "region": "SCOTLAND", "valid": true},
-    {"input": "9876543210", "region": "SCOTLAND", "valid": false, "note": "synthetic number, not in the Scotland range"},
-    {"input": "4000000632", "region": "ENGLAND_WALES_IOM", "valid": true},
-    {"input": "9876543210", "region": "ENGLAND_WALES_IOM", "valid": false}
+    { "input": "0101011113", "region": "SCOTLAND", "valid": true },
+    {
+      "input": "9876543210",
+      "region": "SCOTLAND",
+      "valid": false,
+      "note": "synthetic number, not in the Scotland range"
+    },
+    { "input": "4000000632", "region": "ENGLAND_WALES_IOM", "valid": true },
+    { "input": "9876543210", "region": "ENGLAND_WALES_IOM", "valid": false }
   ],
   "region_of": [
-    {"number": "0101011113", "region": "SCOTLAND"},
-    {"number": "3462950622", "region": "NORTHERN_IRELAND"},
-    {"number": "4000000632", "region": "ENGLAND_WALES_IOM"},
-    {"number": "8453035113", "region": "EIRE"},
-    {"number": "9234760735", "region": "SYNTHETIC"}
+    { "number": "0101011113", "region": "SCOTLAND" },
+    { "number": "3462950622", "region": "NORTHERN_IRELAND" },
+    { "number": "4000000632", "region": "ENGLAND_WALES_IOM" },
+    { "number": "8453035113", "region": "EIRE" },
+    { "number": "9234760735", "region": "SYNTHETIC" }
   ],
   "range_boundaries": [
-    {"range": "UNALLOCATED_1", "start": 10, "end": 99999999},
-    {"range": "SCOTLAND", "start": 100000000, "end": 3112999999, "note": "corrected boundary - issue #59"},
-    {"range": "NORTHERN_IRELAND", "start": 3200000000, "end": 3999999999},
-    {"range": "SYNTHETIC", "start": 9000000000, "end": 9999999999}
+    { "range": "UNALLOCATED_1", "start": 10, "end": 99999999 },
+    {
+      "range": "SCOTLAND",
+      "start": 100000000,
+      "end": 3112999999,
+      "note": "corrected boundary - issue #59"
+    },
+    { "range": "NORTHERN_IRELAND", "start": 3200000000, "end": 3999999999 },
+    { "range": "SYNTHETIC", "start": 9000000000, "end": 9999999999 }
   ]
 }

--- a/tests/vectors/nhs_number_cases.json
+++ b/tests/vectors/nhs_number_cases.json
@@ -1,0 +1,54 @@
+{
+  "_about": "Language-agnostic behavioural test vectors for nhs-number, frozen against the Python reference implementation (2.0.0). Validated by tests/test_vectors.py, and intended to be consumed verbatim by ports in other languages (e.g. the Rust crate at ../nhs-number-rs) so the implementations stay in lockstep. 'region' names map to the package's REGION_* constants; 'range' names to the RANGE_* constants. Python-specific type-robustness cases (None, lists, objects, floats) live in the native test files, not here, because they are not expressible across languages.",
+  "calculate_checksum": [
+    {"identifier": "987654321", "checksum": 0},
+    {"identifier": "400000063", "checksum": 2},
+    {"identifier": "000000006", "checksum": 10, "note": "checksum 10 means no single check digit can match - any number with this identifier is invalid"},
+    {"identifier": "12345", "checksum": null, "note": "fewer than 9 digits"},
+    {"identifier": "1234567890123", "checksum": null, "note": "more than 9 digits"}
+  ],
+  "standardise": [
+    {"input": "9876543210", "output": "9876543210"},
+    {"input": "987 654 3210", "output": "9876543210"},
+    {"input": "987-654-3210", "output": "9876543210"},
+    {"input": "  9876543210  ", "output": "9876543210"},
+    {"input": "", "output": ""},
+    {"input": "abcdefghij", "output": ""},
+    {"input": "987654321X", "output": "", "note": "non-digit character"}
+  ],
+  "standardise_from_int": [
+    {"input": 9876543210, "output": "9876543210"},
+    {"input": 0, "output": "0000000000"},
+    {"input": -1, "output": "", "note": "negative"},
+    {"input": 99999999999, "output": "", "note": "more than 10 digits"}
+  ],
+  "is_valid": [
+    {"input": "9876543210", "valid": true},
+    {"input": "1234567890", "valid": false},
+    {"input": "0000000000", "valid": true, "note": "checksum-valid; range is not checked without for_region (issue #44)"},
+    {"input": "987 654 3210", "valid": true, "note": "formatted input is standardised first"},
+    {"input": "", "valid": false},
+    {"input": "garbage", "valid": false},
+    {"input": "0101011113", "valid": true, "note": "Scotland CHI, 01/01/01 - a real date"},
+    {"input": "0113011113", "valid": false, "note": "Scotland CHI, month 13 - impossible date; checksum is valid, only the date rejects it"}
+  ],
+  "is_valid_for_region": [
+    {"input": "0101011113", "region": "SCOTLAND", "valid": true},
+    {"input": "9876543210", "region": "SCOTLAND", "valid": false, "note": "synthetic number, not in the Scotland range"},
+    {"input": "4000000632", "region": "ENGLAND_WALES_IOM", "valid": true},
+    {"input": "9876543210", "region": "ENGLAND_WALES_IOM", "valid": false}
+  ],
+  "region_of": [
+    {"number": "0101011113", "region": "SCOTLAND"},
+    {"number": "3462950622", "region": "NORTHERN_IRELAND"},
+    {"number": "4000000632", "region": "ENGLAND_WALES_IOM"},
+    {"number": "8453035113", "region": "EIRE"},
+    {"number": "9234760735", "region": "SYNTHETIC"}
+  ],
+  "range_boundaries": [
+    {"range": "UNALLOCATED_1", "start": 10, "end": 99999999},
+    {"range": "SCOTLAND", "start": 100000000, "end": 3112999999, "note": "corrected boundary - issue #59"},
+    {"range": "NORTHERN_IRELAND", "start": 3200000000, "end": 3999999999},
+    {"range": "SYNTHETIC", "start": 9000000000, "end": 9999999999}
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a **language-agnostic behavioural test-vector** layer, in preparation for the planned Rust port (a sibling project). The core contract is frozen as JSON and validated against this reference implementation, so a port in any language can consume the same vectors and stay in lockstep with Python.

## What's here

- `tests/vectors/nhs_number_cases.json` - frozen expected results for `calculate_checksum`, `standardise` (string + integer inputs), `is_valid` (including CHI date validation and `for_region`), region detection (`region_of`), and `range_boundaries` (with the #59-corrected Scotland boundary).
- `tests/test_vectors.py` - a parametrized harness that runs every vector through this implementation and asserts the frozen result.

**244 tests pass (+37), 100% line and branch coverage maintained, black-clean.**

## Why

- **Cross-language parity:** the JSON is meant to be vendored verbatim by ports (starting with the Rust crate), so "does the port agree with Python?" becomes a single test run and drift is visible rather than silent.
- **Regression pin:** it also freezes the Python behaviour - if a future change alters a result, the harness catches it here.

## Scope / deliberately excluded

- Python-type-robustness cases (`None`, lists, objects, floats) stay in the native test files - they are not expressible across languages.
- Generation is property-based (random output), so it stays as native property tests; the vectors cover deterministic behaviour only.

A short note in `spec/testing.md` documenting the convention can follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
