### PR TITLE
Remove unused MkDocs plugins from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,9 @@ pytest
 # documentation site - Zensical
 zensical
 
-# for the feature which displays authors at the bottom of the page
-mkdocs-git-committers-plugin-2
-
-# for the feature which displays last edit date at the bottom of the page
-mkdocs-git-revision-date-localized-plugin
-
-# for the feature which enables 'foldable' admonition text (used for large code blocks)
-mkdocs-macros-plugin
-
-# for the PDF export feature
-mkdocs-with-pdf
+# The following MkDocs plugins were removed because Zensical has no plugin
+# system yet and cannot consume them. Re-add when Zensical supports them:
+#   mkdocs-git-committers-plugin-2             (page authors footer)
+#   mkdocs-git-revision-date-localized-plugin  (last-edit date footer)
+#   mkdocs-macros-plugin                       (foldable admonitions)
+#   mkdocs-with-pdf                            (PDF export)


### PR DESCRIPTION
## Summary

Removes four MkDocs plugins from `requirements.txt` that Zensical cannot consume.

The docs site migrated from MkDocs to Zensical (1.3.7), which has no plugin/module system yet. These plugins were installed on every docs build but unused - nothing references them (`mkdocs.yml` declares only `markdown_extensions`, and the workflow runs `zensical build`).

Removed (with an inline note to re-add when Zensical supports plugins):

- `mkdocs-git-committers-plugin-2` - page authors footer
- `mkdocs-git-revision-date-localized-plugin` - last-edit date footer
- `mkdocs-macros-plugin` - foldable admonitions
- `mkdocs-with-pdf` - PDF export

No change to the published site (those features were already inactive under Zensical) - just a leaner, honest dependency list and a faster docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)