### PR TITLE
Remove unused mkdocs-material dev-dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ python = "^3.8"
 [tool.poetry.dev-dependencies]
 pytest = "^9.0.0"
 black = "^26.0.0"
-mkdocs-material = "^9.7.0"
 
 [tool.poetry.urls]
 "Issue Tracker" = "https://github.com/uk-fci/nhs-number/issues"


### PR DESCRIPTION
Removes `mkdocs-material` from `pyproject.toml`'s dev-dependencies. The docs site moved from MkDocs to Zensical, so it is no longer needed.

It was only ever a declaration: nothing installs the pyproject dev-deps (CI installs `pytest`/`pytest-cov` directly, the docs build uses `requirements.txt`), so there is no functional change - just an honest dependency list.

Left as-is, being cosmetic and separate from the dependency: the vestigial `mkdocs.yml` Material theme config (only used by the unused `mkdocs build` fallback) and the `mkdocs-material-` cache-key label in the docs workflow. Happy to tidy those too if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)