### PR TITLE
Remove the docs-build pip cache step (drops actions/cache)

### DIFF
--- a/.github/workflows/github-pages-docs-publish.yml
+++ b/.github/workflows/github-pages-docs-publish.yml
@@ -32,15 +32,6 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Cache Python packages
-        run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v5
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: ~/.cache
-          restore-keys: |
-            mkdocs-material-
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Removes the "Cache Python packages" block (a weekly `~/.cache` cache via `actions/cache@v5`) from the docs deploy workflow.

It was lifted verbatim from the Material for MkDocs Actions recipe; its original value - caching Material's plugin/build cache - no longer applies under Zensical, leaving only a marginal pip-download speedup. Dropping it **removes an external action from the workflow** - a little less supply-chain attack surface - in exchange for a few seconds of build time.

No functional change to the published site: the build still installs from `requirements.txt` and runs `zensical build`. The seven other steps are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)