### PR TITLE
Align dependabot.yml to house-style (cooldown + grouping)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,42 @@
-# Set update schedule for GitHub Actions
+# Dependabot version updates, following ~/code/house-style/ci.md:
+# weekly batched minor/patch PRs per ecosystem, with a cooldown so a freshly
+# published release has time to be noticed, yanked, or superseded before it
+# lands. Cooldown does not apply to security updates - those arrive immediately.
 
 version: 2
+
 updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 1
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14
+    groups:
+      routine-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
-
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      # Check for updates to Python dependencies every week
-      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 1
+    groups:
+      github-actions-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Brings `.github/dependabot.yml` up to the house-style CI baseline (`~/code/house-style/ci.md`) - the maintenance companion to the SHA-pinning in #72.

For both `pip` and `github-actions`:

- **Grouping** - minor + patch bumps batch into one weekly (Monday) PR per ecosystem instead of one PR per dependency; majors stay separate for individual review.
- **Cooldown** - a freshly published release waits before Dependabot proposes it: `pip` uses 3d / 7d / 14d for patch / minor / major (1d default), `github-actions` uses 1d. This gives a bad release time to be noticed/yanked before it lands - which matters more now that Dependabot is auto-bumping pinned action SHAs. Security updates bypass the cooldown and arrive immediately.

No change to CI behaviour itself - only how dependency-update PRs are scheduled and batched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)