### PR TITLE
2.0.1: py.typed marker + modernize dev-dependencies

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,10 @@ title: Changelog
 authors: Dr Marcus Baw
 ---
 
+## 2.0.1
+
+- Adds a `py.typed` marker (PEP 561) so type-checkers and IDEs pick up the package's type annotations when it is installed as a dependency. No API or behaviour change. Resolves #65.
+
 ## 2.0.0
 
 **Breaking changes** to CHI number validation and to `generate()`. The changes make the library more accurate for real-world use; callers relying on the previous behaviour may see different results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nhs-number"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python package to provide utilities for NHS Numbers, including validity checks, normalisation, and generation."
 authors = [
     "Andy Law <andy.law@roslin.ed.ac.uk>",


### PR DESCRIPTION
## Summary

Adds a PEP 561 `py.typed` marker so downstream type-checkers and IDEs pick up the package's type annotations. Resolves #65 (reported by @George-D-S).

The package is fully type-hinted, but without `py.typed` a consumer's mypy/pyright treats it as untyped and ignores every annotation. The marker is the one-file fix.

## Verified it's packaged

Built the wheel and confirmed `nhs_number/py.typed` is included - poetry-core packages it automatically, no `include` directive needed:

```
nhs_number/__init__.py
nhs_number/constants.py
nhs_number/details.py
nhs_number/generate.py
nhs_number/py.typed        <-- present
nhs_number/standardise.py
nhs_number/validate.py
```

Bumps to **2.0.1** with a changelog entry so the marker reaches consumers on the next release (merging to `main` auto-publishes). No API or behaviour change; 244 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)