### PR TITLE
Add workflow_dispatch to publish workflows; simplify docs build step

### DIFF
--- a/.github/workflows/github-pages-docs-publish.yml
+++ b/.github/workflows/github-pages-docs-publish.yml
@@ -42,12 +42,7 @@ jobs:
           fi
 
       - name: Build site
-        run: |
-          if command -v zensical >/dev/null 2>&1; then
-            zensical build --clean
-          else
-            mkdocs build --clean
-          fi
+        run: zensical build --clean
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+  # Allows a release to be re-run from the Actions tab without needing a new
+  # push to `main` - e.g. if a publish run was missed or its deployment
+  # approval expired.
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - staging
+  # Allows a test.pypi.org publish to be run from the Actions tab against any
+  # ref, without needing a push to `staging`.
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Two small workflow fixes.

### 1. `workflow_dispatch` on the publish workflows

`pypi-publish.yml` and `testpypi-publish.yml` could only be triggered by a push to `main` / `staging`. That meant a missed publish run, or one whose deployment approval expired, could not be re-run without manufacturing a commit.

This is not hypothetical: the 2.0.1 release (the `py.typed` fix, #65) was merged on 27 Jun but never published - its only publish run sat awaiting approval and was auto-failed after GitHub's 30-day timeout, with no way to retry it.

Both workflows now also accept `workflow_dispatch`, so a release can be re-run from the Actions tab.

### 2. Docs build step simplified

```yaml
- run: |
    if command -v zensical >/dev/null 2>&1; then
      zensical build --clean
    else
      mkdocs build --clean          # dead code
    fi
```

The `mkdocs` fallback can no longer succeed - MkDocs and its plugins were removed from `requirements.txt` (#68, #69). Replaced with a direct `zensical build --clean`.

All four workflow files validated as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)