### PR TITLE
Remove staging branch; add contributing guide

### DIFF
--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -1,14 +1,14 @@
 # .github/workflows/testpypi-publish.yml
 # This workflow will build a Python project, and publish it to TEST.pypi.org
 
-name: Publish library to TEST.pypi.org on push to `staging` branch
+name: Publish library to TEST.pypi.org (manual)
 
 on:
-  push:
-    branches:
-      - staging
-  # Allows a test.pypi.org publish to be run from the Actions tab against any
-  # ref, without needing a push to `staging`.
+  # Run from the Actions tab against any ref. This replaces the old
+  # `push: staging` trigger: the `staging` branch drifted a long way behind
+  # `main` and repeatedly caught contributors out by becoming the default base
+  # for their PRs, so it has been removed. Dispatching this workflow gives the
+  # same test.pypi.org smoke-test from whichever ref you actually want.
   workflow_dispatch:
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
     needs: ["build"]
     environment: test-release
 
-    name: Upload from staging branch to TEST.pypi.org
+    name: Upload to TEST.pypi.org
     runs-on: ubuntu-latest
 
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+Thanks for considering a contribution to `nhs-number`. This is a small library maintained by a couple of people in their own time, and pull requests, issues and questions are all welcome.
+
+## Branching: everything targets `main`
+
+**There is one long-lived branch: `main`.** Please branch from `main` and open your pull request against `main`.
+
+There is no `develop` or `staging` branch. Both previously existed, drifted a long way behind `main`, and repeatedly caught contributors out - a pull request opened against one of them shows dozens of unrelated files as though they were your changes. If you have an older fork that still has those branches, delete them and re-branch from an up-to-date `main`.
+
+If you find your PR shows far more changed files than you expected, that is almost always the symptom of a stale base branch. Rebase onto current `main` and it should shrink to just your work.
+
+## Getting set up
+
+```bash
+git clone https://github.com/uk-fci/nhs-number.git
+cd nhs-number
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Before you open a pull request
+
+Three things run in CI and will block a merge if they fail, so it is worth running them locally first.
+
+**1. Tests, with 100% coverage.** The suite must pass and coverage must stay at 100% for both lines and branches:
+
+```bash
+pytest --cov=nhs_number --cov-branch --cov-fail-under=100
+```
+
+The 100% requirement is deliberate but is treated as a floor, not a goal - see [`spec/testing.md`](spec/testing.md) for the testing philosophy, including how we pin behaviour and what we deliberately do not test. If your change adds a defensive branch that genuinely cannot be reached, say so in the PR rather than contriving a test for it, and we will work out the right answer together.
+
+**2. Formatting with black.** Line length is 79, configured in `pyproject.toml`:
+
+```bash
+black .
+```
+
+**3. The shared test vectors.** `tests/vectors/nhs_number_cases.json` freezes the library's core behaviour (checksum, standardisation, validation, region detection, range boundaries) in a language-agnostic form, so that ports in other languages can be checked against the same contract. If you intentionally change any of that behaviour, update the vectors in the same pull request and explain why.
+
+Optionally, `tox` will run the suite across the supported Python versions plus the formatting check, if you have those interpreters available:
+
+```bash
+tox
+```
+
+## Changelog and versioning
+
+If your change should be released, bump the version and add a changelog entry. Use the helper script, which takes `patch`, `minor` or `major`:
+
+```bash
+s/version++ patch
+```
+
+It refuses to run unless `docs/changelog.md` already contains a `## <new version>` section, so **write the changelog entry first**. Every released version has an entry; please keep it that way.
+
+Not every change needs a release. Documentation-only and CI-only changes are usually merged without a version bump.
+
+## How releases happen
+
+Merging to `main` triggers the PyPI publish workflow. The upload step is gated behind a manual deployment approval on the `release` environment, so nothing reaches PyPI without a maintainer approving it.
+
+To smoke-test a build on Test PyPI first, run the **Publish library to TEST.pypi.org** workflow manually from the Actions tab against any branch or tag.
+
+## Conventions worth knowing
+
+- **GitHub Actions are pinned to a full commit SHA** with a trailing `# vX.Y.Z` comment, rather than a mutable tag. A tag can be re-pointed if an action's repository is compromised; a SHA cannot. Dependabot keeps the pins current. If you add a step, pin it the same way and confirm the SHA from the action's repository rather than from memory.
+- **Public API is a closed set.** `tests/test_public_api.py` pins every name exported from the package, so adding one is a deliberate decision and removing one is a breaking change. If you add a public name, add it to that test too.
+- **Input handling never raises.** `is_valid()`, `NhsNumber()` and `standardise_format()` return `False` / construct cleanly / return `""` for input they cannot parse, rather than throwing. Please preserve that.
+
+## Issues
+
+Bug reports, questions and feature ideas are all welcome in [GitHub Issues](https://github.com/uk-fci/nhs-number/issues). For a bug, the most useful thing you can include is the exact input and what you expected to happen - NHS numbers are full of edge cases, and a concrete example is worth a lot.
+
+Please do not include real patients' NHS numbers in issues, pull requests, tests or documentation. Use `generate()`, which produces numbers from the synthetic/test range by default.
+
+## Licence
+
+By contributing, you agree that your contributions will be licensed under the [MIT Licence](LICENSE) that covers this project.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,14 @@
+---
+title: Contributing
+authors: Dr Marcus Baw
+---
+
+<!--
+This page includes the canonical CONTRIBUTING.md from the repository root, so
+that the docs site and the file GitHub shows to contributors can never drift
+apart. Edit CONTRIBUTING.md, not this file.
+-->
+
+--8<--
+CONTRIBUTING.md
+--8<--

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -42,6 +42,6 @@ Also add a note to the `docs/changelog.md` file to explain the updates.
 
 Publication to PyPi is handled by GitHub Actions. The workflows are defined in the `.github/workflows` folder.
 
-Pushes of code to the `staging` branch will trigger a publication to Test PyPi.
+Merging a pull request to `main` triggers a publication to live PyPi. The upload step requires a manual deployment approval on the `release` environment, so a release is never published without a maintainer approving it.
 
-Pushes of code to the `main` branch will trigger a publication to live PyPi.
+To publish to Test PyPi, run the **Publish library to TEST.pypi.org** workflow manually from the Actions tab, choosing whichever branch or tag you want to smoke-test. (This replaced an older `staging` branch, which drifted behind `main` and kept catching contributors out by becoming the base branch for their pull requests.)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Installation: "installation.md"
       - Usage: "usage.md"
   - Developer Guide:
+      - Contributing: "contributing.md"
       - Project Structure: "developing.md"
       - Documentation: "documentation.md"
       - Useful URLs: "useful_urls.md"


### PR DESCRIPTION
## Summary

Removes the `staging` branch and adds a contributing guide, in the repo root and on the docs site.

## Removing `staging`

`staging` existed only to trigger a Test PyPI publish on push. It had drifted **60 commits behind `main`** and held **no commits that were not already in `main`**, but it kept being picked up as the base branch for contributors' pull requests - most recently @andyatterton's #78, which rendered as *38 files / +2006 lines* purely because of the stale base, and was closed as a result.

Since #82 added `workflow_dispatch` to the Test PyPI workflow, the branch has no remaining purpose: you can now run **Publish library to TEST.pypi.org** from the Actions tab against whichever branch or tag you actually want to smoke-test.

- Drops the `push: staging` trigger (leaving `workflow_dispatch`), and renames the workflow and its upload job accordingly
- Updates `docs/developing.md`, which still told people to push to `staging` to publish to Test PyPI, and now also documents the manual approval gate on the `release` environment

The branch itself is deleted separately.

## Contributing guide

New root **`CONTRIBUTING.md`** (the file GitHub surfaces in the PR and issue UI), covering:

- **the single-branch model** - branch from `main`, target `main`; no `develop`, no `staging` - and the tell-tale symptom of a stale base branch, so the next contributor recognises it
- local setup, and the three gates CI enforces: tests at 100% line+branch coverage, `black`, and the shared test vectors
- changelog and versioning via `s/version++` (which refuses to bump without a changelog entry), and the note that docs-only and CI-only changes usually do not get a release
- how a release actually happens, including the `release` environment approval
- conventions a newcomer would otherwise trip over: SHA-pinned Actions, the closed public-API set, and never-raise input handling
- a request not to put real patients' NHS numbers in issues, tests or docs

**`docs/contributing.md`** includes that file via `pymdownx.snippets`, so the docs site and the GitHub-facing file are one source of truth and cannot drift. Added to the nav under Developer Guide.

## Verified

- `zensical build --clean` → "No issues found"; the included content renders on `/contributing/` with no leftover snippet markers (`check_paths: true` would have failed the build on a bad path)
- Workflow YAML parses; trigger is now `workflow_dispatch` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
