### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nhs-number"
-version = "2.0.1"
+version = "2.1.0"
 description = "Python package to provide utilities for NHS Numbers, including validity checks, normalisation, and generation."
 authors = [
     "Andy Law <andy.law@roslin.ed.ac.uk>",


### PR DESCRIPTION
Release **2.1.0**.

Merging this pull request publishes the release: the auto-tag workflow will
create the `v2.1.0` tag and start the PyPI publish, which then waits for a
deployment approval on the `release` environment.

See [docs/releasing.md](docs/releasing.md) for the full process.

Changelog entry for this version is in `docs/changelog.md`.