### PR TITLE
fix(tests): don't overflow the csv field size limit on Windows

### DIFF
--- a/.github/workflows/test-all-branches.yml
+++ b/.github/workflows/test-all-branches.yml
@@ -11,10 +11,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        # One Windows job, so that platform-specific breakage is caught here
+        # rather than by a contributor. Issue #80 was exactly this: the csv
+        # field size limit overflows a 32-bit C long on Windows, which an
+        # ubuntu-only matrix can never see.
+        include:
+          - os: windows-latest
+            python-version: "3.13"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -30,7 +38,7 @@ jobs:
         run: |
           pytest --cov=nhs_number --cov-branch --cov-report=term --cov-fail-under=100
       - name: Check code formatting with black
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
         run: |
           pip install black
           black --check .

--- a/tests/test_bulk_validation.py
+++ b/tests/test_bulk_validation.py
@@ -18,7 +18,13 @@ import pytest
 
 from nhs_number import is_valid
 
-csv.field_size_limit(sys.maxsize)
+# The csv module's field size limit is a C long. On Windows that is 32-bit,
+# so sys.maxsize overflows it and raises at import time (see issue #80). Fall
+# back to the largest value a 32-bit signed long can hold.
+try:
+    csv.field_size_limit(sys.maxsize)
+except OverflowError:
+    csv.field_size_limit(2**31 - 1)
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "local-test-data")
 DATA_FILE = os.path.join(DATA_DIR, "testdata-909090-valid-nhs-numbers.csv")


### PR DESCRIPTION
Resolves #80.

## The bug

`tests/test_bulk_validation.py` calls `csv.field_size_limit(sys.maxsize)` at import time. That limit is a **C long**, which is 32-bit on Windows, so `sys.maxsize` overflows it:

```
ERROR tests/test_bulk_validation.py - OverflowError: Python int too large to convert to C long
```

Because it happens at import, it fails *collection* of the module - so a Windows contributor sees an error before any test runs. Reported by @andyatterton, who also supplied the fix.

## The fix

```python
try:
    csv.field_size_limit(sys.maxsize)
except OverflowError:
    csv.field_size_limit(2**31 - 1)
```

Verified by simulating the Windows behaviour on Linux - patching `field_size_limit` to reject anything above `2**31 - 1`, then running the exact code from the module:

```
attempted limits: [9223372036854775807, 2147483647]
survived the simulated Windows overflow: True
effective limit now: 2147483647
```

## Also: one Windows CI job

The test matrix was **ubuntu-only**, so this class of breakage could never be caught by CI - it could only be found by a contributor hitting it, which is exactly what happened.

Adds a single `windows-latest` job on 3.13 (7 Linux jobs + 1 Windows = 8). The bulk dataset is committed to the repo, so that job really does execute the offending import and would have caught this. The black check is pinned to the ubuntu job so it does not run twice.

Happy to drop the CI part if you would rather keep this PR to the one-line fix - branch protection has no pinned check names, so the matrix rename is safe either way.

258 tests pass, 100% coverage, black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)