### PR TITLE
docs: link Mark Wardle's Clojure/ClojureScript NHS number library

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Please do - and you are welcome to build on our work. We publish a language-agno
 
 It is MIT licensed, like the rest of the project: **use it freely, no permission needed.** Attribution is appreciated but not required. See [Implementing an NHS Numbers package in other languages](https://uk-fci.github.io/nhs-number/other-languages/) for what the vectors cover, what is deliberately left out and why, and how to use them.
 
+## Other libraries
+
+Similar libraries for other languages:
+
+* Clojure / ClojureScript: [wardle/nhs-number](https://github.com/wardle/nhs-number) by Mark Wardle - validation, formatting and generation of UK NHS Numbers
+
+If you maintain one we have missed, please [open an issue](https://github.com/uk-fci/nhs-number/issues) and we will add it.
+
 ## Changelog
 
 <https://uk-fci.github.io/nhs-number/>

--- a/docs/other-languages.md
+++ b/docs/other-languages.md
@@ -55,7 +55,17 @@ This project is **MIT licensed**, and that covers the test vectors as much as th
 
 - **You may use the vectors freely**, including in a commercial product, and including in a library that competes with this one. You do not need to ask.
 - **Attribution is appreciated but not required.** If you found this useful, a line in your README saying your implementation is checked against the vectors from [uk-fci/nhs-number](https://github.com/uk-fci/nhs-number) is genuinely helpful to us - it is how other people find the project, and how we find out our work was worth doing. But it is a courtesy, not a condition. Build the thing.
-- **We would love to know.** Open an issue or a discussion to tell us your implementation exists and we will link it from these docs. If you find a case where our vectors are wrong, or a case we should have covered, that is one of the most valuable contributions you can make - please raise it.
+- **We would love to know.** Open an issue or a discussion to tell us your implementation exists and we will add it to the list below. If you find a case where our vectors are wrong, or a case we should have covered, that is one of the most valuable contributions you can make - please raise it.
+
+## Libraries in other languages
+
+| Language | Library | Notes |
+| --- | --- | --- |
+| Clojure / ClojureScript | [wardle/nhs-number](https://github.com/wardle/nhs-number) by Mark Wardle | Validation, formatting and generation of UK NHS Numbers. Eclipse Public License 2.0. |
+
+These are independent projects, not maintained by us - but they solve the same problem, and if one of them fits your stack better than porting the algorithm yourself, use it.
+
+Maintaining another one? [Tell us](https://github.com/uk-fci/nhs-number/issues) and we will list it here.
 
 ## Before you start
 


### PR DESCRIPTION
## Summary

Reciprocates the courtesy: [wardle/nhs-number](https://github.com/wardle/nhs-number) has an **Other libraries** section at the bottom of its README pointing at this project, and we did not point back.

Adds a matching **Other libraries** section to our README, and a **Libraries in other languages** table to the [other-languages docs page](docs/other-languages.md) - which already said *"tell us your implementation exists and we will link it from these docs"*, so this makes good on that promise with its first entry.

## Details

- **Clojure / ClojureScript** - [wardle/nhs-number](https://github.com/wardle/nhs-number) by Mark Wardle: validation, formatting and generation of UK NHS Numbers, EPL 2.0.
- Described using the repository's own wording rather than a paraphrase, so we do not misrepresent it. Note it is *Clojure/Script* - both Clojure and ClojureScript - not ClojureScript alone.
- Both places note these are independent projects we do not maintain, and invite other maintainers to tell us about theirs.
- In the README the section sits next to *"Implementing this in another language?"*, so the invitation to port and the list of existing ports read together.

Links verified (HTTP 200), `zensical build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)