### PR TITLE
Modernise Python support, switch Black to Ruff

### DIFF
--- a/.github/workflows/test-all-branches.yml
+++ b/.github/workflows/test-all-branches.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         # One Windows job, so that platform-specific breakage is caught here
         # rather than by a contributor. Issue #80 was exactly this: the csv
         # field size limit overflows a 32-bit C long on Windows, which an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,14 @@
-[tool.poetry]
+[project]
 name = "nhs-number"
-version = "2.1.0"
+version = "3.0.0"
 description = "Python package to provide utilities for NHS Numbers, including validity checks, normalisation, and generation."
 authors = [
-    "Andy Law <andy.law@roslin.ed.ac.uk>",
-    "Marcus Baw <marcus@marcusbaw.com>",
-    ]
+    { name = "Andy Law", email = "andy.law@roslin.ed.ac.uk" },
+    { name = "Marcus Baw", email = "marcus@marcusbaw.com" },
+]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "nhs_number"}]
-homepage = "https://uk-fci.github.io/nhs-number/"
-documentation = "https://uk-fci.github.io/nhs-number/"
-repository = "https://github.com/uk-fci/nhs-number"
-
-exclude = ["tests/local-test-data/*"]
+requires-python = ">=3.10"
 
 classifiers = [
     'Development Status :: 5 - Production/Stable',
@@ -24,28 +19,29 @@ classifiers = [
     'Intended Audience :: Healthcare Industry',
     'Intended Audience :: Science/Research',
     'Topic :: Scientific/Engineering :: Medical Science Apps.',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
-    ]
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
+dependencies = []
 
-[tool.poetry.dev-dependencies]
-pytest = "^9.0.0"
-black = "^26.0.0"
-
-[tool.poetry.urls]
+[project.urls]
+Homepage = "https://uk-fci.github.io/nhs-number/"
+Documentation = "https://uk-fci.github.io/nhs-number/"
+Repository = "https://github.com/uk-fci/nhs-number"
 "Issue Tracker" = "https://github.com/uk-fci/nhs-number/issues"
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.poetry]
+packages = [{ include = "nhs_number" }]
+exclude = ["tests/local-test-data/*"]
 
-[tool.black]
-line-length = 79
+[tool.poetry.group.dev.dependencies]
+pytest = "^9.0.0"
+ruff = "^0.15.0"
+
+[build-system]
+requires = ["poetry-core>=2.0"]
+build-backend = "poetry.core.masonry.api"

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,32 +5,11 @@
 # if a future Ruff release alters its defaults.
 
 target-version = "py310"
-line-length = 88
-indent-width = 4
-
-# Exclude generated / vendored / test-fixture content in addition to Ruff's
-# standard exclude list (.git, .venv, __pycache__, build, dist, etc.).
-extend-exclude = ["tests/local-test-data"]
+line-length = 79
 
 [lint]
 # Default Ruff rule selection: Pyflakes (F) plus the subset of pycodestyle
 # errors Ruff enables out of the box (E4 imports, E7 statements, E9 runtime).
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = []
 
-# Allow autofix for all enabled rules when `--fix` is passed.
-fixable = ["ALL"]
-unfixable = []
-
-# Default naming convention for dunder-like variables recognised as valid.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-[format]
-# Default Ruff formatter behaviour (Black-compatible).
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
-line-ending = "auto"
-
-[lint.pydocstyle]
-convention = "pep257"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,36 @@
+# Ruff configuration for nhs-number
+#
+# These values mirror Ruff's own defaults as of versions < 0.16, pinned
+# explicitly so the project's lint/format behaviour doesn't silently change
+# if a future Ruff release alters its defaults.
+
+target-version = "py310"
+line-length = 88
+indent-width = 4
+
+# Exclude generated / vendored / test-fixture content in addition to Ruff's
+# standard exclude list (.git, .venv, __pycache__, build, dist, etc.).
+extend-exclude = ["tests/local-test-data"]
+
+[lint]
+# Default Ruff rule selection: Pyflakes (F) plus the subset of pycodestyle
+# errors Ruff enables out of the box (E4 imports, E7 statements, E9 runtime).
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow autofix for all enabled rules when `--fix` is passed.
+fixable = ["ALL"]
+unfixable = []
+
+# Default naming convention for dunder-like variables recognised as valid.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Default Ruff formatter behaviour (Black-compatible).
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[lint.pydocstyle]
+convention = "pep257"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = black, py{38,39,310,311,312,313,314}
+envlist = ruff-lint, ruff, py{310,311,312,313,314}
 skip_missing_interpreters = true
 
 [testenv]
@@ -10,8 +10,14 @@ deps =
     pytest-cov
 commands = pytest --cov=nhs_number --cov-branch --cov-fail-under=100
 
-[testenv:black]
-description = Check code formatting with Black
+[testenv:ruff-lint]
+description = Lint code with Ruff
 skip_install = true
-deps = black
-commands = black --check .
+deps = ruff
+commands = ruff check .
+
+[testenv:ruff]
+description = Check code formatting with Ruff
+skip_install = true
+deps = ruff
+commands = ruff format --check .


### PR DESCRIPTION
I have updated the project to be more 'modern', with this i have added a ruff.toml and selected pre ruff 0.16 rules, this is because a lot rules are turned on and potentially would cause a lot of changes all at once.