### PR TITLE
Add optional sex-parity check for CHI numbers (#66)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,10 @@ title: Changelog
 authors: Dr Marcus Baw
 ---
 
+## 2.2.0
+
+- Adds an optional `sex` keyword to `is_valid()` and `NhsNumber()`. If the number is a Scotland CHI number, checks the parity of its 9th digit (odd=male, even=female) against the supplied sex; a mismatch makes the number invalid. Has no effect on non-CHI numbers, on values that cannot express a determinate sex (`"indeterminate"`, `"not_known"`), or when omitted (the default) - existing calls are unaffected. Accepts both words and the NHS's numeric/letter codes (`1`/`2` for male/female, `9`/`0`/`"X"` for indeterminate/not-known), so a value can be passed straight from a database column without translation. Raises `ValueError` for an unrecognised value. See [Sex and gender in this library](sex-and-gender.md) and issue #66 for the full reasoning and the NHS Data Dictionary references behind the design.
+
 ## 2.1.0
 
 - Adds `disguise()`, which generates a deterministic, valid fake NHS/CHI/HSC number from a real one given a seed. The same number and seed always produce the same fake, so a dataset can be de-identified consistently. NHS numbers are replaced from the synthetic range so a fake can never collide with a live issued number; CHI fakes carry a different, randomly chosen date of birth with digits 7-8 set to `99` to mark them as fake. Contributed by @andyatterton.

--- a/docs/sex-and-gender.md
+++ b/docs/sex-and-gender.md
@@ -1,0 +1,95 @@
+---
+title: Sex and gender in this library
+authors: Dr Marcus Baw
+---
+
+# Sex and gender in this library
+
+A Scotland CHI number's 9th digit encodes a person's sex by parity: odd for male, even for female. `is_valid()` and `NhsNumber()` can optionally check a number against a supplied sex - this page explains what that check does, why the parameter is called `sex` and not `gender`, and how to skip the check safely for records where sex isn't recorded as a determinate value.
+
+## Why `sex`, not `gender`
+
+NHS's own data standards draw a clear line between these two concepts, and have split what used to be a single field into two:
+
+| Attribute | Meaning |
+| --- | --- |
+| [`PERSON STATED GENDER CODE`](https://www.datadictionary.nhs.uk/data_elements/person_stated_gender_code.html) | self-declared or inferred **gender** |
+| [`PERSON PHENOTYPIC SEX`](https://www.datadictionary.nhs.uk/data_elements/person_phenotypic_sex.html) | biological **sex** |
+
+A CHI number's 9th-digit parity is fixed at the point the number is issued and encodes biological sex, not declared gender identity - so `PERSON PHENOTYPIC SEX` is the standard this library follows, and `sex` is the accurate name for the parameter.
+
+The older, single `PERSON GENDER CODE` field these two replaced has been formally retired:
+
+> "PERSON GENDER CODE will be replaced with PERSON STATED GENDER CODE or PERSON PHENOTYPIC SEX CLASSIFICATION, which is the most recent approved national information standard."
+> — [NHS Data Dictionary](https://www.datadictionary.nhs.uk/attributes/person_gender_code.html)
+
+NHS's live Personal Demographics Service (PDS) FHIR API keeps the same distinction: an NHS response on the [developer community forum](https://developer.community.nhs.uk/t/admin-gender-in-pds/8970) states that the API's `gender` field "should not [be] conflated with 'sex at birth'."
+
+## What the check actually does
+
+**One rule governs all behaviour: the check can only ever reduce validity by disagreeing with an actual parity digit on an actual CHI number. In every other circumstance it is inert.**
+
+That single rule covers every case:
+
+- the number isn't a CHI number → `sex` is accepted, but has no effect
+- `sex` is a value that can't express a determinate sex (see below) → accepted, no effect
+- `sex` is omitted (the default) → no check at all, today's behaviour
+
+Only a determinate `"male"` or `"female"` value, checked against an actual CHI number, can ever flip a result from valid to invalid.
+
+```python
+from nhs_number import is_valid
+
+is_valid("0101011113")                    # True  - no sex check
+is_valid("0101011113", sex="male")        # True  - 9th digit is odd, matches
+is_valid("0101011113", sex="female")      # False - 9th digit is odd, mismatch
+is_valid("4000000632", sex="female")      # True  - not a CHI number, sex is ignored
+is_valid("0101011113", sex="not_known")   # True  - can't be checked, ignored
+```
+
+## Accepted values
+
+Both words and the NHS numeric/letter codes are accepted, so you can pass a value straight from a database column without translating it first:
+
+| Meaning | Word | Retired `PERSON GENDER CODE` | Current `PERSON STATED GENDER CODE` / `PERSON PHENOTYPIC SEX` | Affects the result? |
+| --- | --- | --- | --- | --- |
+| Male | `"male"` | `1` | `1` | Yes |
+| Female | `"female"` | `2` | `2` | Yes |
+| Indeterminate / Not Specified | `"indeterminate"` | `9` | `9` | No - inert |
+| Not Known | `"not_known"` | `0` | `"X"` | No - inert |
+
+Male and Female are `1`/`2` in every version of the NHS coding, so those two are unambiguous regardless of which standard your data came from. The "not known"/"indeterminate" codes differ between the retired and current standards (`0` vs `"X"`, "Not Specified" vs "Indeterminate") - it doesn't matter which one your data uses, because both are inert here: a single parity digit cannot distinguish "not known" from "indeterminate" from "not specified", so there is nothing to gain by treating them differently.
+
+Words are case-insensitive and tolerate surrounding whitespace (`"Male"`, `" male "`, `"MALE"` all work).
+
+## What happens with an unrecognised value
+
+`sex` is caller-supplied configuration, not the messy real-world data that `nhs_number` itself can be - so unlike an unparseable NHS number (which returns `False`, never raises), an unrecognised `sex` value raises `ValueError`:
+
+```python
+is_valid("0101011113", sex="woman")   # raises ValueError
+is_valid("0101011113", sex=3)         # raises ValueError
+```
+
+This matches the existing convention for other caller-configuration errors in this library, such as passing something other than a `Region` to `generate(for_region=...)`.
+
+This is deliberate: a typo in a hard-coded literal (`"mael"` instead of `"male"`) is a programming bug, and should fail loudly rather than being silently treated as "no check" - which is what would happen if it were ignored instead.
+
+## Using it with `NhsNumber`
+
+`NhsNumber` accepts the same `sex` keyword, with identical behaviour - a mismatch is reflected in `.valid`:
+
+```python
+from nhs_number import NhsNumber
+
+NhsNumber("0101011113", sex="male").valid    # True
+NhsNumber("0101011113", sex="female").valid  # False
+```
+
+## References
+
+- [`PERSON STATED GENDER CODE`](https://www.datadictionary.nhs.uk/data_elements/person_stated_gender_code.html) - NHS Data Dictionary
+- [`PERSON PHENOTYPIC SEX`](https://www.datadictionary.nhs.uk/data_elements/person_phenotypic_sex.html) - NHS Data Dictionary
+- [`PERSON GENDER CODE`](https://www.datadictionary.nhs.uk/attributes/person_gender_code.html) - NHS Data Dictionary (retired)
+- [Personal Demographics Service - FHIR API](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir) - NHS Digital
+- [Issue #66](https://github.com/uk-fci/nhs-number/issues/66) - the discussion this design came out of

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,6 +19,7 @@ Returns `False` if the NHS Number is not valid.
       - `123-456-7890`
       - `1234567890`
 - `for_region` (*optional, default=None, `Region`*): If provided, additionally validates number is included within the given [`Region`](#regions) range.
+- `sex` (*optional, keyword-only, default=None, `str | int`*): If provided and the number is a Scotland CHI number, checks the number's parity digit against the supplied sex. See [Sex and gender in this library](sex-and-gender.md) for the full behaviour and accepted values.
 
 ```python
 import nhs_number
@@ -46,6 +47,21 @@ nhs_number.is_valid('0101011113')
 nhs_number.is_valid('0113011113')
 # False - there is no 13th month
 ```
+
+A CHI number's 9th digit also encodes sex by parity (odd=male, even=female). Optionally check it with `sex=`:
+
+```python
+nhs_number.is_valid('0101011113', sex='male')
+# True  - 9th digit is odd, matches
+
+nhs_number.is_valid('0101011113', sex='female')
+# False - 9th digit is odd, mismatch
+
+nhs_number.is_valid('0101011113', sex=1)
+# True  - the NHS numeric code for male works too
+```
+
+Omitting `sex`, passing a non-CHI number, or passing a value that can't express a determinate sex (`"indeterminate"`, `"not_known"`, or their NHS codes) never affects the result - see [Sex and gender in this library](sex-and-gender.md) for the full table of accepted values and the reasoning behind them.
 
 ## `normalise_number()`
 
@@ -152,6 +168,16 @@ nhs_number = NhsNumber('9876543210')
 
 vars(nhs_number)
 # {'nhs_number': '9876543210', 'identifier_digits': '987654321', 'check_digit': 0, 'valid': True, 'calculated_checksum': 0, 'region': <nhs_number.constants.Region object at 0x000001A0AD3CD490>, 'region_comment': 'Not to be issued (Synthetic/test patients PDS)'}
+```
+
+`NhsNumber` accepts the same `sex=` keyword as `is_valid()`, and a mismatch is reflected in `.valid`:
+
+```python
+NhsNumber('0101011113', sex='male').valid
+# True
+
+NhsNumber('0101011113', sex='female').valid
+# False
 ```
 
 ## Regions

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -124,7 +124,23 @@ is_valid('0113011113')
 
 Both numbers have a valid check digit. The second is rejected because `011301` claims a **13th month**.
 
-## 7. Getting the details, not just true/false
+## 7. Optionally, check the CHI number's sex too
+
+A CHI number's 9th digit also encodes sex, by parity - odd for male, even for female. `is_valid()` never checks this unless you ask it to.
+
+```python
+from nhs_number import is_valid
+
+is_valid('0101011113', sex='male')
+# True
+
+is_valid('0101011113', sex='female')
+# False
+```
+
+Both numbers above are the same CHI number - only the expected sex differs. It only ever affects the result for an actual CHI number and a determinate `"male"`/`"female"` value; everything else (a non-CHI number, `"indeterminate"`, `"not_known"`, or omitting `sex` entirely) leaves the result unchanged. See [Sex and gender in this library](sex-and-gender.md) for the full reasoning, including why the parameter is called `sex` rather than `gender`.
+
+## 8. Getting the details, not just true/false
 
 When you want to know *why*, use the `NhsNumber` object.
 
@@ -166,7 +182,7 @@ bad.region_comment
 # 'Number did not match a known NHS number range'
 ```
 
-## 8. Generating numbers for testing
+## 9. Generating numbers for testing
 
 Need test data? `generate()` produces valid numbers - and **by default it only draws from the synthetic/test range**, so a generated number can never collide with a real patient's.
 
@@ -239,7 +255,7 @@ is_valid(generate(valid=False)[0])
 !!! warning "Only `for_region=REGION_SYNTHETIC` is guaranteed safe"
     The default is the synthetic range, which is safe. But if you explicitly ask for a live region - England, Scotland, Northern Ireland - you will get numbers from a range that real patients are issued from. Never use those against live systems.
 
-## 9. Disguising real numbers
+## 10. Disguising real numbers
 
 New in 2.1.0. `disguise()` turns a real number into a fake one that is still structurally valid, deterministically - the same number and seed always give the same fake, so a dataset stays internally consistent.
 
@@ -285,12 +301,13 @@ The date is deliberately not preserved - a date of birth is identifying in its o
 !!! warning "Disguising is not anonymisation"
     The mapping is one-way (you cannot recover the original from the fake and the seed), but anyone holding **both** your seed and your original data can reproduce it. Treat the seed as a secret, and treat disguised data according to your own information-governance rules.
 
-## 10. Recap
+## 11. Recap
 
 | You want to… | Use |
 | --- | --- |
 | check a number | `is_valid(number)` |
 | check it belongs to a region | `is_valid(number, for_region=REGION_X)` |
+| check a CHI number's sex digit | `is_valid(number, sex="male")` |
 | tidy a number for storage | `normalise_number(number)` |
 | find out *why* it failed | `NhsNumber(number)` |
 | make safe test numbers | `generate()` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Introduction:
       - "index.md"
       - About NHS Numbers: "nhs-numbers.md"
+      - Sex and gender in this library: "sex-and-gender.md"
   - Getting Started:
       - Installation: "installation.md"
       - Walkthrough: "walkthrough.md"

--- a/nhs_number/details.py
+++ b/nhs_number/details.py
@@ -36,6 +36,8 @@ class NhsNumber:
     valid: bool
         Whether the NHS number is valid or not according to the checksum
         comparison. ``False`` for any input that ``is_valid()`` would reject.
+        If ``sex`` is supplied and the number is a Scotland CHI number, a
+        mismatch with the number's parity digit also makes this ``False``.
     calculated_checksum: int | None
         The checksum calculated from the identifier digits, so you can compare
         it to the check digit. ``None`` if the input could not be parsed.
@@ -45,6 +47,13 @@ class NhsNumber:
     region_comment: str
         The label of the matched region, or an explanatory message if no
         region matched.
+
+    Optional keyword argument:
+
+    sex: str | int | None
+        If the number is a Scotland CHI number, checks that the parity of
+        its 9th digit matches the supplied sex - see ``is_valid()`` for the
+        accepted values and full behaviour, which this delegates to.
 
     Usage:
     >>> from nhs_number import NhsNumber
@@ -64,7 +73,7 @@ class NhsNumber:
 
     """
 
-    def __init__(self, nhs_number):
+    def __init__(self, nhs_number, *, sex=None):
         self.nhs_number = nhs_number
 
         # Standardise first so formatted strings ("987 654 3210"), ints, and
@@ -79,12 +88,16 @@ class NhsNumber:
             self.calculated_checksum = calculate_checksum(
                 self.identifier_digits
             )
-            self.valid = is_valid(standardised)
         else:
             self.identifier_digits = ""
             self.check_digit = None
             self.calculated_checksum = None
-            self.valid = False
+
+        # is_valid() validates `sex` before it looks at the number itself,
+        # so call it unconditionally (not only when standardised is
+        # truthy) - an unrecognised sex value should raise the same way
+        # whether or not nhs_number itself is well-formed.
+        self.valid = is_valid(nhs_number, sex=sex)
 
         self.region = None
         self.region_comment = "Number did not match a known NHS number range"

--- a/nhs_number/validate.py
+++ b/nhs_number/validate.py
@@ -18,6 +18,61 @@ from datetime import datetime
 from nhs_number.standardise import standardise_format
 from nhs_number.constants import Region, REGION_SCOTLAND
 
+_SEX_MALE = "male"
+_SEX_FEMALE = "female"
+
+# Values that are accepted but can never affect the result, because CHI
+# parity is a single digit and can only ever encode two states. Covers both
+# the current NHS PERSON PHENOTYPIC SEX / PERSON STATED GENDER CODE
+# ("indeterminate", "not_known", 9, "X") and the retired PERSON GENDER CODE
+# (0 for "Not Known"; 9 there means "Not Specified", already covered above).
+# See https://uk-fci.github.io/nhs-number/sex-and-gender/ for the full
+# mapping and the reasoning behind it.
+_SEX_INERT = frozenset({"indeterminate", "not_known", 9, 0, "x"})
+
+
+def _normalise_sex(sex: str | int | None) -> str | None:
+    """
+    Normalise a caller-supplied sex value to "male", "female", or None.
+
+    Accepts the words "male" / "female" / "indeterminate" / "not_known"
+    (case insensitive), and the NHS numeric/letter codes: 1 / 2 for
+    male/female (stable across every NHS sex/gender code list), and
+    9 / 0 / "X" for the various "indeterminate" / "not known" / "not
+    specified" states - which are all treated identically, since a single
+    parity digit cannot distinguish between them.
+
+    Returns None for anything that should never affect validation: no
+    value supplied, or one of the inert states above. Raises ValueError for
+    anything unrecognised, including True/False (bool is a subclass of int
+    in Python, but is never a meaningful sex code).
+    """
+    if sex is None:
+        return None
+
+    error = ValueError(
+        f"Unrecognised sex value: {sex!r}. Use 'male', 'female', "
+        "'indeterminate', or 'not_known', or the NHS numeric/letter codes "
+        "1, 2, 9, 0, 'X'."
+    )
+
+    if isinstance(sex, bool):
+        raise error
+    if isinstance(sex, str):
+        key = sex.strip().lower()
+    elif isinstance(sex, int):
+        key = sex
+    else:
+        raise error
+
+    if key in (_SEX_MALE, 1):
+        return _SEX_MALE
+    if key in (_SEX_FEMALE, 2):
+        return _SEX_FEMALE
+    if key in _SEX_INERT:
+        return None
+    raise error
+
 
 def calculate_checksum(identifier_digits: str) -> int | None:
     """
@@ -42,7 +97,9 @@ def calculate_checksum(identifier_digits: str) -> int | None:
     return checksum
 
 
-def is_valid(nhs_number: str, for_region: Region = None) -> bool:
+def is_valid(
+    nhs_number: str, for_region: Region = None, *, sex: str | int = None
+) -> bool:
     """
     Checks the supplied NHS number (as a string) is valid and returns True
     or False.
@@ -59,7 +116,21 @@ def is_valid(nhs_number: str, for_region: Region = None) -> bool:
     How NHS Number validation works:
             https://www.datadictionary.nhs.uk/attributes/nhs_number.html
 
+    :param sex: optional. If the number is a Scotland CHI number, checks
+        that the parity of its 9th digit (odd=male, even=female) matches the
+        supplied sex - a mismatch makes the number invalid. Has no effect on
+        non-CHI numbers, or on a sex value that cannot express a determinate
+        sex ("indeterminate", "not_known", or their NHS numeric/letter
+        codes). Accepts "male", "female", "indeterminate", "not_known"
+        (case insensitive), or the NHS codes 1, 2, 9, 0, "X". Raises
+        ValueError for any other value. See
+        https://uk-fci.github.io/nhs-number/sex-and-gender/ for the
+        reasoning and the full code mapping.
     """
+    # A bad sex value is a caller error, and is checked before anything else
+    # so it raises consistently regardless of whether nhs_number is valid.
+    normalised_sex = _normalise_sex(sex)
+
     # Normalise the NHS number to remove any spaces or dashes
     nhs_number = standardise_format(nhs_number)
     if not nhs_number:
@@ -78,6 +149,15 @@ def is_valid(nhs_number: str, for_region: Region = None) -> bool:
             datetime.strptime(nhs_number[:6], "%d%m%y")
         except ValueError:
             return False
+
+        # The 9th digit's parity encodes sex: odd=male, even=female. Only
+        # meaningful for a determinate sex value - see #66.
+        if normalised_sex is not None:
+            ninth_digit_is_odd = int(nhs_number[8]) % 2 == 1
+            if normalised_sex == _SEX_MALE and not ninth_digit_is_odd:
+                return False
+            if normalised_sex == _SEX_FEMALE and ninth_digit_is_odd:
+                return False
 
     # Test for checksum validity
     # The first 9 numbers are used to calculate the checksum, which should

--- a/tests/test_sex.py
+++ b/tests/test_sex.py
@@ -1,0 +1,142 @@
+"""
+Tests for the sex-parity check on Scotland CHI numbers - see issue #66.
+
+Fixtures: 0101011113 (01/01/01, valid checksum, 9th digit '1' - odd, so
+male by parity) and 0101011121 (same date, 9th digit '2' - even, so female
+by parity). Both are valid CHI numbers with no sex check applied.
+"""
+
+import pytest
+
+from nhs_number import NhsNumber, REGION_ENGLAND_WALES_IOM, is_valid
+
+CHI_MALE = "0101011113"  # 9th digit odd
+CHI_FEMALE = "0101011121"  # 9th digit even
+NON_CHI = "4000000632"  # valid, England/Wales/IoM - no parity digit at all
+
+
+# ---------------------------------------------------------------------------
+# The core parity check
+# ---------------------------------------------------------------------------
+
+
+def test_matching_sex_is_valid():
+    assert is_valid(CHI_MALE, sex="male") is True
+    assert is_valid(CHI_FEMALE, sex="female") is True
+
+
+def test_mismatched_sex_is_invalid():
+    assert is_valid(CHI_MALE, sex="female") is False
+    assert is_valid(CHI_FEMALE, sex="male") is False
+
+
+def test_sex_omitted_is_unaffected():
+    assert is_valid(CHI_MALE) is True
+    assert is_valid(CHI_FEMALE) is True
+
+
+# ---------------------------------------------------------------------------
+# Inert cases - the "one rule": sex can only ever reduce validity by
+# disagreeing with an actual parity digit on an actual CHI number.
+# ---------------------------------------------------------------------------
+
+
+def test_sex_ignored_for_non_chi_numbers():
+    # A mismatch would fail this if the number were Scotland-range, but it
+    # is not, so sex has no effect either way.
+    assert is_valid(NON_CHI, sex="male") is True
+    assert is_valid(NON_CHI, sex="female") is True
+
+
+def test_sex_ignored_for_non_chi_numbers_with_region():
+    assert (
+        is_valid(NON_CHI, for_region=REGION_ENGLAND_WALES_IOM, sex="female")
+        is True
+    )
+
+
+@pytest.mark.parametrize("indeterminate_value", ["indeterminate", "not_known"])
+def test_indeterminate_words_are_inert(indeterminate_value):
+    assert is_valid(CHI_MALE, sex=indeterminate_value) is True
+    assert is_valid(CHI_FEMALE, sex=indeterminate_value) is True
+
+
+@pytest.mark.parametrize("inert_code", [9, 0, "X", "x"])
+def test_inert_numeric_and_letter_codes(inert_code):
+    assert is_valid(CHI_MALE, sex=inert_code) is True
+    assert is_valid(CHI_FEMALE, sex=inert_code) is True
+
+
+# ---------------------------------------------------------------------------
+# NHS numeric codes for male/female - stable across every NHS sex/gender
+# code list (retired PERSON GENDER CODE and current PERSON STATED GENDER
+# CODE / PERSON PHENOTYPIC SEX all agree 1=Male, 2=Female).
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_codes_match_word_behaviour():
+    assert is_valid(CHI_MALE, sex=1) is True
+    assert is_valid(CHI_MALE, sex=2) is False
+    assert is_valid(CHI_FEMALE, sex=2) is True
+    assert is_valid(CHI_FEMALE, sex=1) is False
+
+
+# ---------------------------------------------------------------------------
+# Case insensitivity and whitespace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["male", "Male", "MALE", " male ", "male\t"])
+def test_words_are_case_and_whitespace_insensitive(value):
+    assert is_valid(CHI_MALE, sex=value) is True
+
+
+# ---------------------------------------------------------------------------
+# Unrecognised values raise, matching the for_region convention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["woman", "man", "M", "F", "", "  ", 3, 100, -1, 1.0, [], {}, object()],
+)
+def test_unrecognised_sex_value_raises(bad_value):
+    with pytest.raises(ValueError):
+        is_valid(CHI_MALE, sex=bad_value)
+
+
+@pytest.mark.parametrize("bad_bool", [True, False])
+def test_bool_is_rejected_even_though_it_is_an_int_subclass(bad_bool):
+    with pytest.raises(ValueError):
+        is_valid(CHI_MALE, sex=bad_bool)
+
+
+def test_unrecognised_sex_value_raises_even_for_invalid_number():
+    """A bad `sex` is a caller error and should surface regardless of
+    whether nhs_number itself is well-formed."""
+    with pytest.raises(ValueError):
+        is_valid("garbage", sex="woman")
+
+
+def test_unrecognised_sex_value_raises_even_when_number_is_not_chi():
+    with pytest.raises(ValueError):
+        is_valid(NON_CHI, sex="woman")
+
+
+# ---------------------------------------------------------------------------
+# NhsNumber threads sex through to is_valid()
+# ---------------------------------------------------------------------------
+
+
+def test_nhs_number_valid_reflects_sex_match():
+    assert NhsNumber(CHI_MALE, sex="male").valid is True
+    assert NhsNumber(CHI_MALE, sex="female").valid is False
+
+
+def test_nhs_number_sex_default_is_unaffected():
+    assert NhsNumber(CHI_MALE).valid is True
+
+
+def test_nhs_number_raises_for_bad_sex_even_with_garbage_number():
+    with pytest.raises(ValueError):
+        NhsNumber("not a number at all", sex="woman")

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -99,6 +99,19 @@ def test_is_valid_for_region_vectors(case):
 
 
 @pytest.mark.parametrize(
+    "case",
+    _cases("is_valid_with_sex"),
+    ids=lambda c: f'{c["input"]}-sex={c["sex"]!r}',
+)
+def test_is_valid_with_sex_vectors(case):
+    if case.get("raises"):
+        with pytest.raises(ValueError):
+            is_valid(case["input"], sex=case["sex"])
+    else:
+        assert is_valid(case["input"], sex=case["sex"]) is case["valid"]
+
+
+@pytest.mark.parametrize(
     "case", _cases("region_of"), ids=lambda c: c["number"]
 )
 def test_region_of_vectors(case):

--- a/tests/vectors/nhs_number_cases.json
+++ b/tests/vectors/nhs_number_cases.json
@@ -69,6 +69,82 @@
     { "input": "4000000632", "region": "ENGLAND_WALES_IOM", "valid": true },
     { "input": "9876543210", "region": "ENGLAND_WALES_IOM", "valid": false }
   ],
+  "is_valid_with_sex": [
+    {
+      "input": "0101011113",
+      "sex": "male",
+      "valid": true,
+      "note": "9th digit is odd - male by parity"
+    },
+    {
+      "input": "0101011113",
+      "sex": "female",
+      "valid": false,
+      "note": "mismatch: 9th digit is odd (male), not even"
+    },
+    {
+      "input": "0101011121",
+      "sex": "female",
+      "valid": true,
+      "note": "9th digit is even - female by parity"
+    },
+    {
+      "input": "0101011121",
+      "sex": "male",
+      "valid": false,
+      "note": "mismatch: 9th digit is even (female), not odd"
+    },
+    {
+      "input": "0101011113",
+      "sex": 1,
+      "valid": true,
+      "note": "NHS numeric code for male - see #66"
+    },
+    { "input": "0101011113", "sex": 2, "valid": false },
+    {
+      "input": "0101011113",
+      "sex": "indeterminate",
+      "valid": true,
+      "note": "inert - a single parity digit cannot express this state"
+    },
+    { "input": "0101011113", "sex": "not_known", "valid": true },
+    {
+      "input": "0101011113",
+      "sex": 9,
+      "valid": true,
+      "note": "inert - retired PERSON GENDER CODE 'Not Specified' / current 'Indeterminate'"
+    },
+    {
+      "input": "0101011113",
+      "sex": 0,
+      "valid": true,
+      "note": "inert - retired PERSON GENDER CODE 'Not Known'"
+    },
+    {
+      "input": "0101011113",
+      "sex": "X",
+      "valid": true,
+      "note": "inert - current PERSON STATED GENDER CODE / PERSON PHENOTYPIC SEX 'Not Known'"
+    },
+    {
+      "input": "4000000632",
+      "sex": "female",
+      "valid": true,
+      "note": "not a CHI number - sex has no effect either way"
+    },
+    {
+      "input": "0101011113",
+      "sex": "woman",
+      "raises": true,
+      "note": "unrecognised word"
+    },
+    {
+      "input": "0101011113",
+      "sex": 3,
+      "raises": true,
+      "note": "unrecognised numeric code"
+    }
+  ],
   "region_of": [
     { "number": "0101011113", "region": "SCOTLAND" },
     { "number": "3462950622", "region": "NORTHERN_IRELAND" },


### PR DESCRIPTION
Closes #66.

## Summary

Adds an optional, keyword-only `sex` parameter to `is_valid()` and `NhsNumber()`. For a Scotland CHI number, it checks the parity of the 9th digit (odd=male, even=female) against the supplied sex; a mismatch makes the number invalid.

```python
from nhs_number import is_valid

is_valid('0101011113', sex='male')     # True  - 9th digit is odd, matches
is_valid('0101011113', sex='female')   # False - mismatch
is_valid('4000000632', sex='female')   # True  - not a CHI number, ignored
is_valid('0101011113', sex='not_known')# True  - can't be checked, ignored
is_valid('0101011113')                 # True  - no check, unaffected
```

## The one rule

**The check can only ever reduce validity by disagreeing with an actual parity digit on an actual CHI number. In every other circumstance it's inert.** Non-CHI numbers, indeterminate/not-known values, and omitting `sex` (the default) all behave identically - no effect. This is fully backwards compatible: every existing call to `is_valid()` and `NhsNumber()` is unaffected.

## Accepted values - both words and NHS numeric codes

Per the discussion on #66, this accepts a value straight from a database column without a translation step first:

| Meaning | Word | Retired `PERSON GENDER CODE` | Current `PERSON STATED GENDER CODE` / `PERSON PHENOTYPIC SEX` | Affects result? |
| --- | --- | --- | --- | --- |
| Male | `"male"` | `1` | `1` | Yes |
| Female | `"female"` | `2` | `2` | Yes |
| Indeterminate | `"indeterminate"` | `9` | `9` | No |
| Not Known | `"not_known"` | `0` | `"X"` | No |

Male/Female (`1`/`2`) are stable across every version of the NHS coding, so they're unambiguous. The "not known"/"indeterminate" codes differ between standards, but it doesn't matter which your data uses - both are inert here, since a single parity digit can't distinguish between them anyway.

Words are case-insensitive and whitespace-tolerant. An unrecognised value (`sex="woman"`, `sex=3`) raises `ValueError` - matching the existing convention for other caller-configuration errors (e.g. a bad `for_region` on `generate()`). `True`/`False` are explicitly rejected even though `bool` is an `int` subclass in Python, mirroring the existing guard in `standardise_format()`.

## Why `sex`, not `gender`

The NHS Data Dictionary splits what was a single retired field (`PERSON GENDER CODE`) into two current ones: `PERSON STATED GENDER CODE` (self-declared gender) and `PERSON PHENOTYPIC SEX` (biological sex). A CHI parity digit is fixed at issuance and encodes the latter, so `sex` is the accurate name. Full reasoning and references in the new docs page.

## Implementation notes

- `NhsNumber.__init__` is restructured to call `is_valid()` unconditionally (previously only when the number could be standardised), so a bad `sex` value raises consistently whether or not `nhs_number` itself is well-formed.
- `sex` is validated *before* the number itself, so a caller error surfaces the same way regardless of number validity.

## Tests

- `tests/test_sex.py` - 37 cases: parity match/mismatch, every inert case, both numeric-code standards, case/whitespace handling, bool rejection, `NhsNumber` threading, and that a bad `sex` raises even alongside a garbage number.
- 14 cases added to the shared `tests/vectors/nhs_number_cases.json`, so ports in other languages (the planned Rust crate) get the identical contract.
- **309 tests pass, 100% line and branch coverage, black clean.**

## Docs

New [`docs/sex-and-gender.md`](docs/sex-and-gender.md): the sex-vs-gender reasoning with NHS Data Dictionary citations, the full accepted-value table (old and current codes side by side), the "one rule" governing behaviour, and why unrecognised values raise. Cross-linked from `usage.md`, a new section 7 in `walkthrough.md` (re-verified against all 37 documented outputs in that page, 0 mismatches), and the docs nav.

## Release

Per [`docs/releasing.md`](docs/releasing.md), this PR carries the **2.2.0 changelog entry** but not the version bump itself - that's a separate `s/version++ minor` step once this merges, consistent with the release cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
