### PR TITLE
fix: mark disguised HSC numbers as fake

### DIFF
--- a/nhs_number/disguise.py
+++ b/nhs_number/disguise.py
@@ -120,6 +120,8 @@ def disguise(real_nhs_number: str, *, seed: int) -> str:
         else:
             min_value, max_value = _fake_range(organization)
             candidate = str(rng.randint(min_value, max_value))
+            if organization == OrganizationType.HSC:
+                candidate = f"{candidate[:6]}99{candidate[8:]}"
 
         check_digit = calculate_checksum(candidate)
 

--- a/tests/test_disguise.py
+++ b/tests/test_disguise.py
@@ -49,6 +49,7 @@ def test_generate_fake_chi_number_has_99_constraint():
 def test_generate_fake_hsc_number_is_valid():
     fake = disguise("3200000010", seed=1)
     assert is_valid(fake)
+    assert fake[6:8] == "99"
     assert len(fake) == 10
 
 


### PR DESCRIPTION
## Summary

- constrain digits 7-8 of disguised HSC numbers to `99`, matching CHI fake-number behaviour
- calculate the check digit after applying the marker
- add regression coverage for the HSC marker

## Testing

- `s/test` (258 passed)
- `s/test tests/test_disguise.py` (14 passed)

Closes #90